### PR TITLE
Tomcat 8 MixedAuthenticator bug

### DIFF
--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -96,9 +96,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         final boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
         this.log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
 
-        final LoginConfig loginConfig = new LoginConfig();
-        loginConfig.setErrorPage("error.html");
-        loginConfig.setLoginPage("login.html");
+        final LoginConfig loginConfig = context.getLoginConfig();
 
         if (principal != null && !ntlmPost) {
             this.log.debug("previously authenticated user: {}", principal.getName());


### PR DESCRIPTION
For the Tomcat 8 MixedAuthenticator, a dummy LoginConfig object was being created and used instead of pulling LoginConfig out of the context.