### PR TITLE
Maintainance and Unit test library change

### DIFF
--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -201,7 +201,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.3.1</version>
+                    <version>1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -390,7 +390,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.8</version>
                     <configuration>
                         <header>${src.relative.loc}/license.txt</header>
                         <excludes>

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -98,7 +98,7 @@
         </site>
     </distributionManagement>
     <properties>
-        <copywrite>2014</copywrite>
+        <copywrite>2015</copywrite>
         <jacoco.minimum.coverage>0.0</jacoco.minimum.coverage>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
         <maven.compiler.source>1.6</maven.compiler.source>

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -206,7 +206,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.5</version>
+                    <version>1.6</version>
                     <configuration>
                         <useAgent>true</useAgent>
                     </configuration>

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -112,7 +112,6 @@
         <git.relative.loc>../..</git.relative.loc>
 
         <assertj.version>1.7.1</assertj.version>
-        <catch-exception.version>1.3.3</catch-exception.version>
         <contiperf.version>2.3.4</contiperf.version>
         <jmockit.version>1.14</jmockit.version>
         <junit.version>4.12</junit.version>
@@ -131,18 +130,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>eu.codearte.catch-exception</groupId>
-            <artifactId>catch-exception</artifactId>
-            <version>${catch-exception.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>mockito-core</artifactId>
-                    <groupId>org.mockito</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
@@ -167,6 +154,12 @@
                     <groupId>org.hamcrest</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>pl.wkr</groupId>
+            <artifactId>fluent-exception-rule</artifactId>
+            <version>1.0.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -465,7 +465,7 @@
                         <dependency>
                             <groupId>org.eclipse.jgit</groupId>
                             <artifactId>org.eclipse.jgit</artifactId>
-                            <version>3.6.1.201501031845-r</version>
+                            <version>3.6.2.201501210735-r</version>
                         </dependency>
                         <dependency>
                             <groupId>org.codehaus.plexus</groupId>

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -317,7 +317,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>2.10</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/Source/JNA/src/site/markdown/README.md
+++ b/Source/JNA/src/site/markdown/README.md
@@ -16,7 +16,7 @@ Unlike many other implementations Waffle on Windows does not require any server-
 Essentials
 ----------
 
-* [Download Version 1.7.1](https://github.com/dblock/waffle/releases/download/Waffle-1.7.1/Waffle.1.7.1.zip)
+* [Download Version 1.7.3](https://github.com/dblock/waffle/releases/download/Waffle-1.7.3/Waffle.1.7.3.zip)
 * [Waffle in Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.dblock.waffle%22)
 * [Waffle Snapshots](https://oss.sonatype.org/content/repositories/snapshots/com/github/dblock/waffle/)
 * [Get Waffle To Work in Tomcat, Jetty, WebSphere, etc.](Docs/ServletSingleSignOnSecurityFilter.md)
@@ -80,7 +80,7 @@ Current status of sonar results for Waffle.
 License and Copyright
 ---------------------
 
-Copyright (c) [Application Security Inc.](http://www.appsecinc.com), 2010-2014 and Contributors. 
+Copyright (c) [Application Security Inc.](http://www.appsecinc.com), 2010-2015 and Contributors. 
 
 This project is licensed under the [Eclipse Public License](https://github.com/dblock/waffle/blob/master/LICENSE).
 

--- a/Source/JNA/waffle-jetty/pom.xml
+++ b/Source/JNA/waffle-jetty/pom.xml
@@ -22,7 +22,7 @@
 
         <el.version>3.0.1-b05</el.version>
         <el-api.version>3.0.1-b04</el-api.version>
-        <jetty.version>9.2.6.v20141205</jetty.version>
+        <jetty.version>9.2.7.v20150116</jetty.version>
         <jdt.version>4.4</jdt.version>
         <jsp.version>2.3.3-b02</jsp.version>
         <jsp-api.version>2.3.2-b01</jsp-api.version>

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
@@ -103,7 +103,7 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      * @return the accessDeniedHandler
      */
     public AccessDeniedHandler getAccessDeniedHandler() {
-        return accessDeniedHandler;
+        return this.accessDeniedHandler;
     }
 
     /**
@@ -122,7 +122,7 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      * @return the authenticationFailureHandler
      */
     public AuthenticationFailureHandler getAuthenticationFailureHandler() {
-        return authenticationFailureHandler;
+        return this.authenticationFailureHandler;
     }
 
     /**
@@ -150,29 +150,29 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
     protected boolean setAuthentication(final HttpServletRequest request, final HttpServletResponse response,
             final Authentication authentication) {
         try {
-            if (authenticationManager != null) {
-                logger.debug("Delegating to custom authenticationmanager");
-                final Authentication customAuthentication = authenticationManager.authenticate(authentication);
+            if (this.authenticationManager != null) {
+                this.logger.debug("Delegating to custom authenticationmanager");
+                final Authentication customAuthentication = this.authenticationManager.authenticate(authentication);
                 SecurityContextHolder.getContext().setAuthentication(customAuthentication);
             }
-            if (authenticationSuccessHandler != null) {
+            if (this.authenticationSuccessHandler != null) {
                 try {
-                    authenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+                    this.authenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication);
                 } catch (final IOException e) {
-                    logger.warn("Error calling authenticationSuccessHandler: " + e.getMessage());
+                    this.logger.warn("Error calling authenticationSuccessHandler: " + e.getMessage());
                     return false;
                 } catch (final ServletException e) {
-                    logger.warn("Error calling authenticationSuccessHandler: " + e.getMessage());
+                    this.logger.warn("Error calling authenticationSuccessHandler: " + e.getMessage());
                     return false;
                 }
             }
         } catch (final AuthenticationException e) {
 
-            logger.warn("Error authenticating user in custom authenticationmanager: " + e.getMessage());
+            this.logger.warn("Error authenticating user in custom authenticationmanager: " + e.getMessage());
             sendAuthenticationFailed(request, response, e);
             return false;
         } catch (final AccessDeniedException e) {
-            logger.warn("Error authorizing user in custom authenticationmanager: " + e.getMessage());
+            this.logger.warn("Error authorizing user in custom authenticationmanager: " + e.getMessage());
             sendAccessDenied(request, response, e);
             return false;
         }
@@ -203,9 +203,9 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      */
     private void sendAuthenticationFailed(final HttpServletRequest request, final HttpServletResponse response,
             final AuthenticationException ae) {
-        if (authenticationFailureHandler != null) {
+        if (this.authenticationFailureHandler != null) {
             try {
-                authenticationFailureHandler.onAuthenticationFailure(request, response, ae);
+                this.authenticationFailureHandler.onAuthenticationFailure(request, response, ae);
                 return;
             } catch (final IOException e) {
                 LOGGER.warn("IOException invoking authenticationFailureHandler: " + e.getMessage());
@@ -228,9 +228,9 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      */
     private void sendAccessDenied(final HttpServletRequest request, final HttpServletResponse response,
             final AccessDeniedException ae) {
-        if (accessDeniedHandler != null) {
+        if (this.accessDeniedHandler != null) {
             try {
-                accessDeniedHandler.handle(request, response, ae);
+                this.accessDeniedHandler.handle(request, response, ae);
                 return;
             } catch (final IOException e) {
                 LOGGER.warn("IOException invoking accessDeniedHandler: " + e.getMessage());
@@ -248,7 +248,7 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      * @return the authenticationSuccessHandler
      */
     public AuthenticationSuccessHandler getAuthenticationSuccessHandler() {
-        return authenticationSuccessHandler;
+        return this.authenticationSuccessHandler;
     }
 
     /**
@@ -267,7 +267,7 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      * @return the authenticationManager
      */
     public AuthenticationManager getAuthenticationManager() {
-        return authenticationManager;
+        return this.authenticationManager;
     }
 
     /**

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
@@ -103,7 +103,7 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      * @return the accessDeniedHandler
      */
     public AccessDeniedHandler getAccessDeniedHandler() {
-        return accessDeniedHandler;
+        return this.accessDeniedHandler;
     }
 
     /**
@@ -122,7 +122,7 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      * @return the authenticationFailureHandler
      */
     public AuthenticationFailureHandler getAuthenticationFailureHandler() {
-        return authenticationFailureHandler;
+        return this.authenticationFailureHandler;
     }
 
     /**
@@ -150,29 +150,29 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
     protected boolean setAuthentication(final HttpServletRequest request, final HttpServletResponse response,
             final Authentication authentication) {
         try {
-            if (authenticationManager != null) {
-                logger.debug("Delegating to custom authenticationmanager");
-                final Authentication customAuthentication = authenticationManager.authenticate(authentication);
+            if (this.authenticationManager != null) {
+                this.logger.debug("Delegating to custom authenticationmanager");
+                final Authentication customAuthentication = this.authenticationManager.authenticate(authentication);
                 SecurityContextHolder.getContext().setAuthentication(customAuthentication);
             }
-            if (authenticationSuccessHandler != null) {
+            if (this.authenticationSuccessHandler != null) {
                 try {
-                    authenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+                    this.authenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication);
                 } catch (final IOException e) {
-                    logger.warn("Error calling authenticationSuccessHandler: " + e.getMessage());
+                    this.logger.warn("Error calling authenticationSuccessHandler: " + e.getMessage());
                     return false;
                 } catch (final ServletException e) {
-                    logger.warn("Error calling authenticationSuccessHandler: " + e.getMessage());
+                    this.logger.warn("Error calling authenticationSuccessHandler: " + e.getMessage());
                     return false;
                 }
             }
         } catch (final AuthenticationException e) {
 
-            logger.warn("Error authenticating user in custom authenticationmanager: " + e.getMessage());
+            this.logger.warn("Error authenticating user in custom authenticationmanager: " + e.getMessage());
             sendAuthenticationFailed(request, response, e);
             return false;
         } catch (final AccessDeniedException e) {
-            logger.warn("Error authorizing user in custom authenticationmanager: " + e.getMessage());
+            this.logger.warn("Error authorizing user in custom authenticationmanager: " + e.getMessage());
             sendAccessDenied(request, response, e);
             return false;
         }
@@ -203,9 +203,9 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      */
     private void sendAuthenticationFailed(final HttpServletRequest request, final HttpServletResponse response,
             final AuthenticationException ae) {
-        if (authenticationFailureHandler != null) {
+        if (this.authenticationFailureHandler != null) {
             try {
-                authenticationFailureHandler.onAuthenticationFailure(request, response, ae);
+                this.authenticationFailureHandler.onAuthenticationFailure(request, response, ae);
                 return;
             } catch (final IOException e) {
                 LOGGER.warn("IOException invoking authenticationFailureHandler: " + e.getMessage());
@@ -228,9 +228,9 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      */
     private void sendAccessDenied(final HttpServletRequest request, final HttpServletResponse response,
             final AccessDeniedException ae) {
-        if (accessDeniedHandler != null) {
+        if (this.accessDeniedHandler != null) {
             try {
-                accessDeniedHandler.handle(request, response, ae);
+                this.accessDeniedHandler.handle(request, response, ae);
                 return;
             } catch (final IOException e) {
                 LOGGER.warn("IOException invoking accessDeniedHandler: " + e.getMessage());
@@ -248,7 +248,7 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      * @return the authenticationSuccessHandler
      */
     public AuthenticationSuccessHandler getAuthenticationSuccessHandler() {
-        return authenticationSuccessHandler;
+        return this.authenticationSuccessHandler;
     }
 
     /**
@@ -267,7 +267,7 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
      * @return the authenticationManager
      */
     public AuthenticationManager getAuthenticationManager() {
-        return authenticationManager;
+        return this.authenticationManager;
     }
 
     /**

--- a/Source/JNA/waffle-tests/pom.xml
+++ b/Source/JNA/waffle-tests/pom.xml
@@ -18,8 +18,7 @@
         <git.relative.loc>../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
-        <!-- Do not update this yet until catch-exception is here (bad internal usage which is why we ditched powermock, no direct alternative here so I will patch) -->
-        <mockito.version>1.10.8</mockito.version>
+        <mockito.version>1.10.19</mockito.version>
     </properties>
     <scm>
         <connection>scm:git:ssh://git@github.com/dblock/waffle.git</connection>
@@ -40,6 +39,7 @@
             <version>${servlet.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- This is required as parent isn't managed so it needs full redefine to override -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/Source/JNA/waffle-tests/src/test/java/waffle/util/AuthorizationHeaderTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/util/AuthorizationHeaderTests.java
@@ -17,11 +17,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Rule;
 import org.junit.Test;
 
-import com.googlecode.catchexception.CatchException;
-import com.googlecode.catchexception.apis.BDDCatchException;
-
+import pl.wkr.fluentrule.api.FluentExpectedException;
 import waffle.mock.http.SimpleHttpRequest;
 
 /**
@@ -30,6 +29,9 @@ import waffle.mock.http.SimpleHttpRequest;
 public class AuthorizationHeaderTests {
 
     private static final String DIGEST_HEADER = "Digest username=\"admin\", realm=\"milton\", nonce=\"YjNjZDgxNDYtOGIwMS00NDk0LTlkMTItYzExMGJkNTcxZjli\", uri=\"/case-user-data/431b971d9e1441d381adb277de4f39f8/test\", response=\"30d2d15e89e0b7596325a12852ae6ca5\", qop=auth, nc=00000025, cnonce=\"fb2f97a275d3d9cb\"";
+
+    @Rule
+    public FluentExpectedException thrown = FluentExpectedException.none();
 
     @Test
     public void testIsNull() {
@@ -123,8 +125,7 @@ public class AuthorizationHeaderTests {
         final SimpleHttpRequest request = new SimpleHttpRequest();
         final AuthorizationHeader header = new AuthorizationHeader(request);
         request.addHeader("Authorization", DIGEST_HEADER);
-        BDDCatchException.when(header).getTokenBytes();
-        BDDCatchException.then(CatchException.caughtException()).isInstanceOf(RuntimeException.class)
-                .hasMessage("Invalid authorization header.");
+        this.thrown.expect(RuntimeException.class).hasMessage("Invalid authorization header.");
+        header.getTokenBytes();
     }
 }

--- a/Source/JNA/waffle-tomcat8/pom.xml
+++ b/Source/JNA/waffle-tomcat8/pom.xml
@@ -20,7 +20,7 @@
         <src.relative.loc>..</src.relative.loc>
         <git.relative.loc>../../..</git.relative.loc>
 
-        <tomcat.version>8.0.17</tomcat.version>
+        <tomcat.version>8.0.18</tomcat.version>
     </properties>
     <scm>
         <connection>scm:git:ssh://git@github.com/dblock/waffle.git</connection>

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -34,12 +34,14 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class GenericWindowsPrincipal extends GenericPrincipal {
 
+    private static final long serialVersionUID = 1L;
+
     /** The sid. */
     private byte[]                      sid;
-    
+
     /** The sid string. */
     private String                      sidString;
-    
+
     /** The groups. */
     private Map<String, WindowsAccount> groups;
 

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -96,7 +96,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         final boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
         this.log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
 
-        final LoginConfig loginConfig = context.getLoginConfig();
+        final LoginConfig loginConfig = this.context.getLoginConfig();
 
         if (principal != null && !ntlmPost) {
             this.log.debug("previously authenticated user: {}", principal.getName());


### PR DESCRIPTION
Keeping plugins / dependencies up-to-date
Replaced catch-exception library which had two issues.  1) it was compiled with java 7 which sort of makes a potential problem since we use java 6.  2) It relies on older jmockit and attempts to that library updated while mostly a success didn't solve core issue.  That said, moving to another much more limble library that only has assertj as a dependency which we use and requires no special considerations.  Code is also slightly cleaner.  So as of this pull request, we are using all the latest dependencies across the board that are part of this project.