### PR TITLE
[issue #203] Catch Win32Exception and make 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 * [#187](https://github.com/dblock/waffle/pull/187): Removed Spring 2 and Tomcat 5 support.
 * [#188](https://github.com/dblock/waffle/issues/188): Added support for service provider to authorize the principal.
 * [#192](https://github.com/dblock/waffle/pull/192): Fix: Tomcat 8 MixedAuthenticator uses LoginConfig out of context.
+* [#206](https://github.com/dblock/waffle/pull/206): Fix issue [#203](https://github.com/dblock/waffle/issues/203)
+  ** Tomcat negotiate filters reporting Win32Error 500 status error instead of 401.
+  ** Related to issue [#107](https://github.com/dblock/waffle/issues/107)
 
-* Created 1.7.x branch for spring 2 and tomcat 5 continued support for one year.
+* Created 1.7.x branch for spring 2 and tomcat 5 continued support for one year.  Only complete show stoppers to be addressed there.
 * Github gh-pages now built via mvn site plugin.
 * We use sfl4j, so use jcl-over-slf4j instead of allowing spring to bring in commons-logging.
 

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -231,6 +231,13 @@ public class NegotiateAuthenticatorTests {
                     break;
                 }
 
+                if (response.getHeader("WWW-Authenticate").startsWith(securityPackage + ",")) {
+                    Assert.assertEquals("close", response.getHeader("Connection"));
+                    Assert.assertEquals(2, response.getHeaderNames().length);
+                    Assert.assertEquals(401, response.getStatus());
+                    return;
+                }
+
                 Assert.assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
                 Assert.assertEquals("keep-alive", response.getHeader("Connection"));
                 Assert.assertEquals(2, response.getHeaderNames().length);

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -25,6 +25,7 @@ import org.apache.catalina.deploy.LoginConfig;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.io.BaseEncoding;
+import com.sun.jna.platform.win32.Win32Exception;
 
 import waffle.util.AuthorizationHeader;
 import waffle.util.NtlmServletRequest;
@@ -106,7 +107,14 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 final byte[] tokenBuffer = authorizationHeader.getTokenBytes();
                 this.log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-                securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+                try {
+                    securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+                } catch (final Win32Exception e) {
+                    this.log.warn("error logging in user: {}", e.getMessage());
+                    this.log.trace("{}", e);
+                    sendUnauthorized(response);
+                    return false;
+                }
                 this.log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
 
                 final byte[] continueTokenBytes = securityContext.getToken();

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -244,6 +244,13 @@ public class NegotiateAuthenticatorTests {
                     break;
                 }
 
+                if (response.getHeader("WWW-Authenticate").startsWith(securityPackage + ",")) {
+                    Assert.assertEquals("close", response.getHeader("Connection"));
+                    Assert.assertEquals(2, response.getHeaderNames().size());
+                    Assert.assertEquals(401, response.getStatus());
+                    return;
+                }
+
                 Assert.assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
                 Assert.assertEquals("keep-alive", response.getHeader("Connection"));
                 Assert.assertEquals(2, response.getHeaderNames().size());

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -24,6 +24,7 @@ import org.apache.catalina.connector.Request;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.io.BaseEncoding;
+import com.sun.jna.platform.win32.Win32Exception;
 
 import waffle.util.AuthorizationHeader;
 import waffle.util.NtlmServletRequest;
@@ -105,7 +106,14 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 final byte[] tokenBuffer = authorizationHeader.getTokenBytes();
                 this.log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-                securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+                try {
+                    securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+                } catch (final Win32Exception e) {
+                    this.log.warn("error logging in user: {}", e.getMessage());
+                    this.log.trace("{}", e);
+                    sendUnauthorized(response);
+                    return false;
+                }
                 this.log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
 
                 final byte[] continueTokenBytes = securityContext.getToken();

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -244,6 +244,13 @@ public class NegotiateAuthenticatorTests {
                     break;
                 }
 
+                if (response.getHeader("WWW-Authenticate").startsWith(securityPackage + ",")) {
+                    Assert.assertEquals("close", response.getHeader("Connection"));
+                    Assert.assertEquals(2, response.getHeaderNames().size());
+                    Assert.assertEquals(401, response.getStatus());
+                    return;
+                }
+
                 Assert.assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
                 Assert.assertEquals("keep-alive", response.getHeader("Connection"));
                 Assert.assertEquals(2, response.getHeaderNames().size());


### PR DESCRIPTION
A fix to capture tomcat 6, 7, and 8 negotiate authenticator
Win32Exception which started occurring around June 2015 per issue #107.
Around that time Exception was switched out for IOException which
allowed Win32Exception to occur.  Now catch that and perform same
actions as IOException.  Left original unit tests capturing fall through
and added new check as this shows Negotiate, NTLM where the comma was
normally expected to be a space.  This does fix the condition but I'm
not 100% certain this is correct from unit test side.