### PR TITLE
Formatting / Compression were disabled

### DIFF
--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -386,6 +386,13 @@
                     <groupId>net.revelc.code</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
                     <version>0.5.2</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.github.hazendaz</groupId>
+                            <artifactId>build-tools</artifactId>
+                            <version>1.1.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>
@@ -986,6 +993,7 @@
                             <targetFolder>${project.basedir}/target/classes</targetFolder>
                             <fileExt>
                                 <fileExt>html</fileExt>
+                                <fileExt>jsp</fileExt>
                                 <fileExt>xhtml</fileExt>
                                 <fileExt>xml</fileExt>
                             </fileExt>
@@ -1124,7 +1132,7 @@
             <id>format</id>
             <activation>
                 <file>
-                    <exists>${src.relative.loc}/format.xml</exists>
+                    <exists>format.xml</exists>
                 </file>
             </activation>
             <build>
@@ -1133,7 +1141,7 @@
                         <groupId>net.revelc.code</groupId>
                         <artifactId>formatter-maven-plugin</artifactId>
                         <configuration>
-                            <configFile>${src.relative.loc}/format.xml</configFile>
+                           <configFile>eclipse-formatter-config.xml</configFile>
                         </configuration>
                         <executions>
                             <execution>

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -112,7 +112,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <src.relative.loc>.</src.relative.loc>
-        <git.relative.loc>../..</git.relative.loc>
 
         <assertj.version>2.1.0</assertj.version>
         <cglib.version>3.1</cglib.version>
@@ -566,9 +565,7 @@
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
                 <configuration>
-                    <dotGitDirectory>${git.relative.loc}/.git</dotGitDirectory>
-                    <!-- Fixes occassional issue in commit id plugin - see 
-                        https://github.com/ktoso/maven-git-commit-id-plugin/issues/61 -->
+                    <!-- Prevent issues, see https://github.com/ktoso/maven-git-commit-id-plugin/issues/61 -->
                     <gitDescribe>
                         <always>true</always>
                     </gitDescribe>

--- a/Source/JNA/waffle-demo/pom.xml
+++ b/Source/JNA/waffle-demo/pom.xml
@@ -26,7 +26,6 @@
     </modules>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
     </properties>
     <scm>
         <connection>scm:git:ssh://git@github.com/dblock/waffle.git</connection>

--- a/Source/JNA/waffle-demo/waffle-filter/compression.xml
+++ b/Source/JNA/waffle-demo/waffle-filter/compression.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Compression>
+<Compression>
+ <!-- Dummy compression file -->
+</Compression>

--- a/Source/JNA/waffle-demo/waffle-filter/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-filter/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>../..</src.relative.loc>
-        <git.relative.loc>../../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-form/compression.xml
+++ b/Source/JNA/waffle-demo/waffle-form/compression.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Compression>
+<Compression>
+ <!-- Dummy compression file -->
+</Compression>

--- a/Source/JNA/waffle-demo/waffle-form/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-form/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>../..</src.relative.loc>
-        <git.relative.loc>../../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-jaas/compression.xml
+++ b/Source/JNA/waffle-demo/waffle-jaas/compression.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Compression>
+<Compression>
+ <!-- Dummy compression file -->
+</Compression>

--- a/Source/JNA/waffle-demo/waffle-jaas/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-jaas/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>../..</src.relative.loc>
-        <git.relative.loc>../../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-mixed-post/compression.xml
+++ b/Source/JNA/waffle-demo/waffle-mixed-post/compression.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Compression>
+<Compression>
+ <!-- Dummy compression file -->
+</Compression>

--- a/Source/JNA/waffle-demo/waffle-mixed-post/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-mixed-post/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>../..</src.relative.loc>
-        <git.relative.loc>../../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-mixed/compression.xml
+++ b/Source/JNA/waffle-demo/waffle-mixed/compression.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Compression>
+<Compression>
+ <!-- Dummy compression file -->
+</Compression>

--- a/Source/JNA/waffle-demo/waffle-mixed/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-mixed/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>../..</src.relative.loc>
-        <git.relative.loc>../../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-negotiate/compression.xml
+++ b/Source/JNA/waffle-demo/waffle-negotiate/compression.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Compression>
+<Compression>
+ <!-- Dummy compression file -->
+</Compression>

--- a/Source/JNA/waffle-demo/waffle-negotiate/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-negotiate/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>../..</src.relative.loc>
-        <git.relative.loc>../../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-spring-filter/compression.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-filter/compression.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Compression>
+<Compression>
+ <!-- Dummy compression file -->
+</Compression>

--- a/Source/JNA/waffle-demo/waffle-spring-filter/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-filter/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>../..</src.relative.loc>
-        <git.relative.loc>../../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-spring-form/compression.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-form/compression.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Compression>
+<Compression>
+ <!-- Dummy compression file -->
+</Compression>

--- a/Source/JNA/waffle-demo/waffle-spring-form/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-form/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>../..</src.relative.loc>
-        <git.relative.loc>../../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-distro/pom.xml
+++ b/Source/JNA/waffle-distro/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <logback.version>1.1.3</logback.version>
     </properties>

--- a/Source/JNA/waffle-jetty/format.xml
+++ b/Source/JNA/waffle-jetty/format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/Source/JNA/waffle-jetty/pom.xml
+++ b/Source/JNA/waffle-jetty/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <el.version>3.0.1-b08</el.version>
         <el-api.version>3.0.1-b04</el-api.version>

--- a/Source/JNA/waffle-jetty/src/main/java/waffle/jetty/DummyClass.java
+++ b/Source/JNA/waffle-jetty/src/main/java/waffle/jetty/DummyClass.java
@@ -18,6 +18,6 @@ package waffle.jetty;
  */
 public class DummyClass {
 
-    // Dummy class to prevent javadoc build issues.  Eventually there will be jetty code.  This ensures no empty javadoc.
+    // Dummy class to prevent javadoc build issues. Eventually there will be jetty code. This ensures no empty javadoc.
 
 }

--- a/Source/JNA/waffle-jetty/src/main/java/waffle/jetty/package-info.java
+++ b/Source/JNA/waffle-jetty/src/main/java/waffle/jetty/package-info.java
@@ -15,10 +15,14 @@
  * Nothing for now, but in the future, this would include:
  *
  * <p>
- *  <a href="http://dev.eclipse.org/svnroot/rt/org.eclipse.jetty/jetty/trunk/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java">org/eclipse/jetty/security/Authenticator.java</a>
+ * <a href=
+ * "http://dev.eclipse.org/svnroot/rt/org.eclipse.jetty/jetty/trunk/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java"
+ * >org/eclipse/jetty/security/Authenticator.java</a>
  * </p>
  * <p>
- *  <a href="http://dev.eclipse.org/svnroot/rt/org.eclipse.jetty/jetty/trunk/jetty-security/src/main/java/org/eclipse/jetty/security/LoginService.java">org/eclipse/jetty/security/LoginService.java</a>
+ * <a href=
+ * "http://dev.eclipse.org/svnroot/rt/org.eclipse.jetty/jetty/trunk/jetty-security/src/main/java/org/eclipse/jetty/security/LoginService.java"
+ * >org/eclipse/jetty/security/LoginService.java</a>
  * </p>
  */
 package waffle.jetty;

--- a/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJetty.java
+++ b/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJetty.java
@@ -36,9 +36,9 @@ public class StartEmbeddedJetty {
      * Main method.
      * 
      * @param args
-     *          input arguments to main.
-     * @throws Exception 
-     *          Exception thrown.
+     *            input arguments to main.
+     * @throws Exception
+     *             Exception thrown.
      */
     public static void main(final String[] args) throws Exception {
         final String path = "../waffle-demo/waffle-filter";

--- a/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJettyValidateNTLMGroup.java
+++ b/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJettyValidateNTLMGroup.java
@@ -53,7 +53,8 @@ public class StartEmbeddedJettyValidateNTLMGroup {
     /**
      * The main method.
      *
-     * @param args the arguments
+     * @param args
+     *            the arguments
      */
     public static void main(final String args[]) {
         System.setProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE");
@@ -85,7 +86,8 @@ public class StartEmbeddedJettyValidateNTLMGroup {
     /**
      * Sets the filter params.
      *
-     * @param fh the new filter params
+     * @param fh
+     *            the new filter params
      */
     private static void setFilterParams(final FilterHolder fh) {
         fh.setInitParameter("principalFormat", "fqn");
@@ -107,13 +109,16 @@ public class StartEmbeddedJettyValidateNTLMGroup {
     public static class InfoServlet extends HttpServlet {
 
         /** The Constant serialVersionUID. */
-        private static final long   serialVersionUID = 1L;
+        private static final long         serialVersionUID = 1L;
 
         /** The authorised groups. */
         private static final List<String> authorisedGroups = Arrays.asList("NTGroup1", "NTGroup2");
 
-        /* (non-Javadoc)
-         * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+        /*
+         * (non-Javadoc)
+         * 
+         * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
+         * javax.servlet.http.HttpServletResponse)
          */
         @Override
         public void doGet(final HttpServletRequest request, final HttpServletResponse response)
@@ -132,8 +137,10 @@ public class StartEmbeddedJettyValidateNTLMGroup {
         /**
          * Checks if is user authorised.
          *
-         * @param request the request
-         * @param authorizedGroups the authorized groups
+         * @param request
+         *            the request
+         * @param authorizedGroups
+         *            the authorized groups
          * @return true, if is user authorised
          */
         private boolean isUserAuthorised(final HttpServletRequest request, final List<String> authorizedGroups) {
@@ -146,7 +153,8 @@ public class StartEmbeddedJettyValidateNTLMGroup {
         /**
          * Gets the users groups.
          *
-         * @param request the request
+         * @param request
+         *            the request
          * @return the users groups
          */
         private List<String> getUsersGroups(final HttpServletRequest request) {
@@ -166,8 +174,10 @@ public class StartEmbeddedJettyValidateNTLMGroup {
         /**
          * Gets the group name.
          *
-         * @param domain the domain
-         * @param groupString the group string
+         * @param domain
+         *            the domain
+         * @param groupString
+         *            the group string
          * @return the group name
          */
         private String getGroupName(final String domain, final String groupString) {

--- a/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJettyValidateNTLMGroup.java
+++ b/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJettyValidateNTLMGroup.java
@@ -116,7 +116,6 @@ public class StartEmbeddedJettyValidateNTLMGroup {
 
         /*
          * (non-Javadoc)
-         * 
          * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
          * javax.servlet.http.HttpServletResponse)
          */

--- a/Source/JNA/waffle-jna/format.xml
+++ b/Source/JNA/waffle-jna/format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/Source/JNA/waffle-jna/pom.xml
+++ b/Source/JNA/waffle-jna/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <guava.version>18.0</guava.version>
         <jna.version>4.1.0</jna.version>

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/RolePrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/RolePrincipal.java
@@ -25,9 +25,9 @@ public class RolePrincipal implements Principal, Serializable {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
-    
+
     /** The fqn. */
-    private final String            fqn;
+    private final String      fqn;
 
     /**
      * A windows principal.
@@ -52,7 +52,8 @@ public class RolePrincipal implements Principal, Serializable {
     /**
      * Role Principal Equals for FQN.
      *
-     * @param o            Object used for Equality Check.
+     * @param o
+     *            Object used for Equality Check.
      * @return true, if successful
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
@@ -51,7 +51,6 @@ public class UserPrincipal implements Principal, Serializable {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -70,7 +69,6 @@ public class UserPrincipal implements Principal, Serializable {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.lang.Object#hashCode()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
@@ -25,9 +25,9 @@ public class UserPrincipal implements Principal, Serializable {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
-    
+
     /** The fqn. */
-    private final String            fqn;
+    private final String      fqn;
 
     /**
      * A user principal.
@@ -49,7 +49,9 @@ public class UserPrincipal implements Principal, Serializable {
         return this.fqn;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -66,7 +68,9 @@ public class UserPrincipal implements Principal, Serializable {
         return false;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.lang.Object#hashCode()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
@@ -54,33 +54,36 @@ public class WindowsLoginModule implements LoginModule {
 
     /** The username. */
     private String               username;
-    
+
     /** The debug. */
     private boolean              debug;
-    
+
     /** The subject. */
     private Subject              subject;
-    
+
     /** The callback handler. */
     private CallbackHandler      callbackHandler;
-    
+
     /** The auth. */
     private IWindowsAuthProvider auth            = new WindowsAuthProviderImpl();
-    
+
     /** The principals. */
     private Set<Principal>       principals;
-    
+
     /** The principal format. */
     private PrincipalFormat      principalFormat = PrincipalFormat.FQN;
-    
+
     /** The role format. */
     private PrincipalFormat      roleFormat      = PrincipalFormat.FQN;
-    
+
     /** The allow guest login. */
     private boolean              allowGuestLogin = true;
 
-    /* (non-Javadoc)
-     * @see javax.security.auth.spi.LoginModule#initialize(javax.security.auth.Subject, javax.security.auth.callback.CallbackHandler, java.util.Map, java.util.Map)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.security.auth.spi.LoginModule#initialize(javax.security.auth.Subject,
+     * javax.security.auth.callback.CallbackHandler, java.util.Map, java.util.Map)
      */
     @Override
     public void initialize(final Subject initSubject, final CallbackHandler initCallbackHandler,
@@ -163,7 +166,8 @@ public class WindowsLoginModule implements LoginModule {
             }
 
             this.username = windowsIdentity.getFqn();
-            WindowsLoginModule.LOGGER.debug("successfully logged in {} ({})", this.username, windowsIdentity.getSidString());
+            WindowsLoginModule.LOGGER.debug("successfully logged in {} ({})", this.username,
+                    windowsIdentity.getSidString());
         } finally {
             windowsIdentity.dispose();
         }
@@ -203,7 +207,8 @@ public class WindowsLoginModule implements LoginModule {
         final Set<Principal> principalsSet = this.subject.getPrincipals();
         principalsSet.addAll(this.principals);
 
-        WindowsLoginModule.LOGGER.debug("committing {} principals", Integer.valueOf(this.subject.getPrincipals().size()));
+        WindowsLoginModule.LOGGER.debug("committing {} principals",
+                Integer.valueOf(this.subject.getPrincipals().size()));
         if (this.debug) {
             for (final Principal principal : principalsSet) {
                 WindowsLoginModule.LOGGER.debug(" principal: {}", principal.getName());

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
@@ -81,7 +81,6 @@ public class WindowsLoginModule implements LoginModule {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.security.auth.spi.LoginModule#initialize(javax.security.auth.Subject,
      * javax.security.auth.callback.CallbackHandler, java.util.Map, java.util.Map)
      */

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/AutoDisposableWindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/AutoDisposableWindowsPrincipal.java
@@ -52,7 +52,9 @@ public class AutoDisposableWindowsPrincipal extends WindowsPrincipal implements 
         super(windowsIdentity, principalFormat, roleFormat);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSessionBindingListener#valueBound(javax.servlet.http.HttpSessionBindingEvent)
      */
     @Override
@@ -60,7 +62,9 @@ public class AutoDisposableWindowsPrincipal extends WindowsPrincipal implements 
         // Do nothing
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSessionBindingListener#valueUnbound(javax.servlet.http.HttpSessionBindingEvent)
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/AutoDisposableWindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/AutoDisposableWindowsPrincipal.java
@@ -54,7 +54,6 @@ public class AutoDisposableWindowsPrincipal extends WindowsPrincipal implements 
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSessionBindingListener#valueBound(javax.servlet.http.HttpSessionBindingEvent)
      */
     @Override
@@ -64,7 +63,6 @@ public class AutoDisposableWindowsPrincipal extends WindowsPrincipal implements 
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSessionBindingListener#valueUnbound(javax.servlet.http.HttpSessionBindingEvent)
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
@@ -87,7 +87,6 @@ public class NegotiateSecurityFilter implements Filter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.Filter#destroy()
      */
     @Override
@@ -97,7 +96,6 @@ public class NegotiateSecurityFilter implements Filter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse,
      * javax.servlet.FilterChain)
      */
@@ -268,7 +266,6 @@ public class NegotiateSecurityFilter implements Filter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.Filter#init(javax.servlet.FilterConfig)
      */
     @SuppressWarnings("unchecked")

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
@@ -55,25 +55,25 @@ public class NegotiateSecurityFilter implements Filter {
     /** The Constant LOGGER. */
     private static final Logger              LOGGER              = LoggerFactory
                                                                          .getLogger(NegotiateSecurityFilter.class);
-    
+
     /** The principal format. */
     private PrincipalFormat                  principalFormat     = PrincipalFormat.FQN;
-    
+
     /** The role format. */
     private PrincipalFormat                  roleFormat          = PrincipalFormat.FQN;
-    
+
     /** The providers. */
     private SecurityFilterProviderCollection providers;
-    
+
     /** The auth. */
     private IWindowsAuthProvider             auth;
-    
+
     /** The allow guest login. */
     private boolean                          allowGuestLogin     = true;
-    
+
     /** The impersonate. */
     private boolean                          impersonate;
-    
+
     /** The Constant PRINCIPALSESSIONKEY. */
     private static final String              PRINCIPALSESSIONKEY = NegotiateSecurityFilter.class.getName()
                                                                          + ".PRINCIPAL";
@@ -85,7 +85,9 @@ public class NegotiateSecurityFilter implements Filter {
         NegotiateSecurityFilter.LOGGER.debug("[waffle.servlet.NegotiateSecurityFilter] loaded");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.Filter#destroy()
      */
     @Override
@@ -93,8 +95,11 @@ public class NegotiateSecurityFilter implements Filter {
         NegotiateSecurityFilter.LOGGER.info("[waffle.servlet.NegotiateSecurityFilter] stopped");
     }
 
-    /* (non-Javadoc)
-     * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse, javax.servlet.FilterChain)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse,
+     * javax.servlet.FilterChain)
      */
     @Override
     public void doFilter(final ServletRequest sreq, final ServletResponse sres, final FilterChain chain)
@@ -138,7 +143,8 @@ public class NegotiateSecurityFilter implements Filter {
                     return;
                 }
 
-                NegotiateSecurityFilter.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+                NegotiateSecurityFilter.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(),
+                        windowsIdentity.getSidString());
 
                 final HttpSession session = request.getSession(true);
                 if (session == null) {
@@ -260,7 +266,9 @@ public class NegotiateSecurityFilter implements Filter {
         return true;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.Filter#init(javax.servlet.FilterConfig)
      */
     @SuppressWarnings("unchecked")
@@ -305,7 +313,9 @@ public class NegotiateSecurityFilter implements Filter {
         if (authProvider != null) {
             try {
                 this.auth = (IWindowsAuthProvider) Class.forName(authProvider).getConstructor().newInstance();
-            } catch (final ClassNotFoundException | IllegalArgumentException | SecurityException | InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            } catch (final ClassNotFoundException | IllegalArgumentException | SecurityException
+                    | InstantiationException | IllegalAccessException | InvocationTargetException
+                    | NoSuchMethodException e) {
                 NegotiateSecurityFilter.LOGGER.error("error loading '{}': {}", authProvider, e.getMessage());
                 NegotiateSecurityFilter.LOGGER.trace("{}", e);
                 throw new ServletException(e);
@@ -332,18 +342,19 @@ public class NegotiateSecurityFilter implements Filter {
             if (classAndParameter.length == 2) {
                 try {
 
-                    NegotiateSecurityFilter.LOGGER.debug("setting {}, {}={}", classAndParameter[0], classAndParameter[1],
-                            implParameter.getValue());
+                    NegotiateSecurityFilter.LOGGER.debug("setting {}, {}={}", classAndParameter[0],
+                            classAndParameter[1], implParameter.getValue());
 
                     final SecurityFilterProvider provider = this.providers.getByClassName(classAndParameter[0]);
                     provider.initParameter(classAndParameter[1], implParameter.getValue());
 
                 } catch (final ClassNotFoundException e) {
-                    NegotiateSecurityFilter.LOGGER.error("invalid class: {} in {}", classAndParameter[0], implParameter.getKey());
+                    NegotiateSecurityFilter.LOGGER.error("invalid class: {} in {}", classAndParameter[0],
+                            implParameter.getKey());
                     throw new ServletException(e);
                 } catch (final Exception e) {
-                    NegotiateSecurityFilter.LOGGER.error("{}: error setting '{}': {}", classAndParameter[0], classAndParameter[1],
-                            e.getMessage());
+                    NegotiateSecurityFilter.LOGGER.error("{}: error setting '{}': {}", classAndParameter[0],
+                            classAndParameter[1], e.getMessage());
                     NegotiateSecurityFilter.LOGGER.trace("{}", e);
                     throw new ServletException(e);
                 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WaffleInfoServlet.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WaffleInfoServlet.java
@@ -45,6 +45,7 @@ public class WaffleInfoServlet extends HttpServlet {
 
     /*
      * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)
      */
@@ -56,6 +57,7 @@ public class WaffleInfoServlet extends HttpServlet {
 
     /*
      * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServlet#doPost(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)
      */
@@ -68,10 +70,14 @@ public class WaffleInfoServlet extends HttpServlet {
     /**
      * Gets the waffle info response.
      *
-     * @param request            the request
-     * @param response            the response
-     * @throws IOException             Signals that an I/O exception has occurred.
-     * @throws ServletException             the servlet exception
+     * @param request
+     *            the request
+     * @param response
+     *            the response
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     public void getWaffleInfoResponse(final HttpServletRequest request, final HttpServletResponse response)
             throws IOException, ServletException {

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WaffleInfoServlet.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WaffleInfoServlet.java
@@ -45,7 +45,6 @@ public class WaffleInfoServlet extends HttpServlet {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)
      */
@@ -57,7 +56,6 @@ public class WaffleInfoServlet extends HttpServlet {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServlet#doPost(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)
      */

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
@@ -35,23 +35,23 @@ import waffle.windows.auth.WindowsAccount;
 public class WindowsPrincipal implements Principal, Serializable {
 
     /** The Constant serialVersionUID. */
-    private static final long           serialVersionUID = 1L;
-    
+    private static final long                 serialVersionUID = 1L;
+
     /** The fqn. */
     private final String                      fqn;
-    
+
     /** The sid. */
     private final byte[]                      sid;
-    
+
     /** The sid string. */
     private final String                      sidString;
-    
+
     /** The roles. */
     private final List<String>                roles;
-    
+
     /** The identity. */
-    private transient IWindowsIdentity  identity;
-    
+    private transient IWindowsIdentity        identity;
+
     /** The groups. */
     private final Map<String, WindowsAccount> groups;
 
@@ -248,7 +248,9 @@ public class WindowsPrincipal implements Principal, Serializable {
         return this.identity;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.lang.Object#toString()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
@@ -250,7 +250,6 @@ public class WindowsPrincipal implements Principal, Serializable {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.lang.Object#toString()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
@@ -36,11 +36,11 @@ import waffle.windows.auth.IWindowsIdentity;
 public class BasicSecurityFilterProvider implements SecurityFilterProvider {
 
     /** The Constant LOGGER. */
-    private static final Logger  LOGGER = LoggerFactory.getLogger(BasicSecurityFilterProvider.class);
-    
+    private static final Logger        LOGGER = LoggerFactory.getLogger(BasicSecurityFilterProvider.class);
+
     /** The realm. */
-    private String               realm  = "BasicSecurityFilterProvider";
-    
+    private String                     realm  = "BasicSecurityFilterProvider";
+
     /** The auth. */
     private final IWindowsAuthProvider auth;
 
@@ -54,8 +54,11 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
         this.auth = newAuthProvider;
     }
 
-    /* (non-Javadoc)
-     * @see waffle.servlet.spi.SecurityFilterProvider#doFilter(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.servlet.spi.SecurityFilterProvider#doFilter(javax.servlet.http.HttpServletRequest,
+     * javax.servlet.http.HttpServletResponse)
      */
     @Override
     public IWindowsIdentity doFilter(final HttpServletRequest request, final HttpServletResponse response)
@@ -71,7 +74,9 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
         return this.auth.logonUser(usernamePasswordArray[0], usernamePasswordArray[1]);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#isPrincipalException(javax.servlet.http.HttpServletRequest)
      */
     @Override
@@ -79,7 +84,9 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
         return false;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#isSecurityPackageSupported(java.lang.String)
      */
     @Override
@@ -87,7 +94,9 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
         return securityPackage.equalsIgnoreCase("Basic");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#sendUnauthorized(javax.servlet.http.HttpServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
@@ -56,7 +56,6 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#doFilter(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)
      */
@@ -76,7 +75,6 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#isPrincipalException(javax.servlet.http.HttpServletRequest)
      */
     @Override
@@ -86,7 +84,6 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#isSecurityPackageSupported(java.lang.String)
      */
     @Override
@@ -96,7 +93,6 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#sendUnauthorized(javax.servlet.http.HttpServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
@@ -95,7 +95,6 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#sendUnauthorized(javax.servlet.http.HttpServletResponse)
      */
     @Override
@@ -108,7 +107,6 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#isPrincipalException(javax.servlet.http.HttpServletRequest)
      */
     @Override
@@ -122,7 +120,6 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#doFilter(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)
      */
@@ -172,7 +169,6 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#isSecurityPackageSupported(java.lang.String)
      */
     @Override
@@ -187,7 +183,6 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#initParameter(java.lang.String, java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
@@ -41,23 +41,24 @@ import waffle.windows.auth.IWindowsSecurityContext;
 public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 
     /** The Constant LOGGER. */
-    private static final Logger  LOGGER           = LoggerFactory.getLogger(NegotiateSecurityFilterProvider.class);
+    private static final Logger        LOGGER           = LoggerFactory
+                                                                .getLogger(NegotiateSecurityFilterProvider.class);
 
     /** The Constant WWW_AUTHENTICATE. */
-    private static final String  WWW_AUTHENTICATE = "WWW-Authenticate";
+    private static final String        WWW_AUTHENTICATE = "WWW-Authenticate";
 
     /** The Constant PROTOCOLS. */
-    private static final String  PROTOCOLS        = "protocols";
-    
+    private static final String        PROTOCOLS        = "protocols";
+
     /** The Constant NEGOTIATE. */
-    private static final String  NEGOTIATE        = "Negotiate";
-    
+    private static final String        NEGOTIATE        = "Negotiate";
+
     /** The Constant NTLM. */
-    private static final String  NTLM             = "NTLM";
+    private static final String        NTLM             = "NTLM";
 
     /** The protocols. */
-    private List<String>         protocols        = new ArrayList<>();
-    
+    private List<String>               protocols        = new ArrayList<>();
+
     /** The auth. */
     private final IWindowsAuthProvider auth;
 
@@ -92,7 +93,9 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
         this.protocols = values;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#sendUnauthorized(javax.servlet.http.HttpServletResponse)
      */
     @Override
@@ -103,19 +106,25 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#isPrincipalException(javax.servlet.http.HttpServletRequest)
      */
     @Override
     public boolean isPrincipalException(final HttpServletRequest request) {
         final AuthorizationHeader authorizationHeader = new AuthorizationHeader(request);
         final boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
-        NegotiateSecurityFilterProvider.LOGGER.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
+        NegotiateSecurityFilterProvider.LOGGER.debug("authorization: {}, ntlm post: {}", authorizationHeader,
+                Boolean.valueOf(ntlmPost));
         return ntlmPost;
     }
 
-    /* (non-Javadoc)
-     * @see waffle.servlet.spi.SecurityFilterProvider#doFilter(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.servlet.spi.SecurityFilterProvider#doFilter(javax.servlet.http.HttpServletRequest,
+     * javax.servlet.http.HttpServletResponse)
      */
     @Override
     public IWindowsIdentity doFilter(final HttpServletRequest request, final HttpServletResponse response)
@@ -127,7 +136,8 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
         // maintain a connection-based session for NTLM tokens
         final String connectionId = NtlmServletRequest.getConnectionId(request);
         final String securityPackage = authorizationHeader.getSecurityPackage();
-        NegotiateSecurityFilterProvider.LOGGER.debug("security package: {}, connection id: {}", securityPackage, connectionId);
+        NegotiateSecurityFilterProvider.LOGGER.debug("security package: {}, connection id: {}", securityPackage,
+                connectionId);
 
         if (ntlmPost) {
             // type 2 NTLM authentication message received
@@ -146,7 +156,8 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
             response.addHeader(NegotiateSecurityFilterProvider.WWW_AUTHENTICATE, securityPackage + " " + continueToken);
         }
 
-        NegotiateSecurityFilterProvider.LOGGER.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
+        NegotiateSecurityFilterProvider.LOGGER.debug("continue required: {}",
+                Boolean.valueOf(securityContext.isContinue()));
         if (securityContext.isContinue() || ntlmPost) {
             response.setHeader("Connection", "keep-alive");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
@@ -159,7 +170,9 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
         return identity;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#isSecurityPackageSupported(java.lang.String)
      */
     @Override
@@ -172,7 +185,9 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
         return false;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.servlet.spi.SecurityFilterProvider#initParameter(java.lang.String, java.lang.String)
      */
     @Override
@@ -184,7 +199,8 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
                 protocolName = protocolName.trim();
                 if (protocolName.length() > 0) {
                     NegotiateSecurityFilterProvider.LOGGER.debug("init protocol: {}", protocolName);
-                    if (protocolName.equals(NegotiateSecurityFilterProvider.NEGOTIATE) || protocolName.equals(NegotiateSecurityFilterProvider.NTLM)) {
+                    if (protocolName.equals(NegotiateSecurityFilterProvider.NEGOTIATE)
+                            || protocolName.equals(NegotiateSecurityFilterProvider.NTLM)) {
                         this.protocols.add(protocolName);
                     } else {
                         NegotiateSecurityFilterProvider.LOGGER.error("unsupported protocol: {}", protocolName);

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
@@ -39,8 +39,9 @@ import waffle.windows.auth.IWindowsIdentity;
 public class SecurityFilterProviderCollection {
 
     /** The Constant LOGGER. */
-    private static final Logger          LOGGER    = LoggerFactory.getLogger(SecurityFilterProviderCollection.class);
-    
+    private static final Logger                LOGGER    = LoggerFactory
+                                                                 .getLogger(SecurityFilterProviderCollection.class);
+
     /** The providers. */
     private final List<SecurityFilterProvider> providers = new ArrayList<>();
 
@@ -81,7 +82,8 @@ public class SecurityFilterProviderCollection {
                 SecurityFilterProviderCollection.LOGGER.error("error loading '{}': {}", providerName, e.getMessage());
                 SecurityFilterProviderCollection.LOGGER.trace("{}", e);
                 throw new RuntimeException(e);
-            } catch (final SecurityException | NoSuchMethodException | IllegalArgumentException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            } catch (final SecurityException | NoSuchMethodException | IllegalArgumentException
+                    | InstantiationException | IllegalAccessException | InvocationTargetException e) {
                 SecurityFilterProviderCollection.LOGGER.error("error loading '{}': {}", providerName, e.getMessage());
                 SecurityFilterProviderCollection.LOGGER.trace("{}", e);
             }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
@@ -83,7 +83,6 @@ public class AuthorizationHeader {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.lang.Object#toString()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
@@ -28,7 +28,7 @@ import com.google.common.io.BaseEncoding;
 public class AuthorizationHeader {
 
     /** The logger. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationHeader.class);
+    private static final Logger      LOGGER = LoggerFactory.getLogger(AuthorizationHeader.class);
 
     /** The request. */
     private final HttpServletRequest request;
@@ -81,7 +81,9 @@ public class AuthorizationHeader {
         throw new RuntimeException("Invalid Authorization header: " + header);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.lang.Object#toString()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/WaffleInfo.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/WaffleInfo.java
@@ -306,16 +306,18 @@ public class WaffleInfo {
             String arg;
             for (int i = 0; i < args.length; i++) {
                 arg = args[i];
-                if (null != arg) switch (arg) {
-                    case "-show":
-                        show = true;
-                        break;
-                    case "-lookup":
-                        lookup.add(args[++i]);
-                        break;
-                    default:
-                        WaffleInfo.LOGGER.error("Unknown Argument: {}", arg);
-                        throw new RuntimeException("Unknown Argument: " + arg);
+                if (null != arg) {
+                    switch (arg) {
+                        case "-show":
+                            show = true;
+                            break;
+                        case "-lookup":
+                            lookup.add(args[++i]);
+                            break;
+                        default:
+                            WaffleInfo.LOGGER.error("Unknown Argument: {}", arg);
+                            throw new RuntimeException("Unknown Argument: " + arg);
+                    }
                 }
             }
         }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/PrincipalFormat.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/PrincipalFormat.java
@@ -19,13 +19,13 @@ package waffle.windows.auth;
  * @author dblock[at]dblock[dot]org
  */
 public enum PrincipalFormat {
-    
+
     /** The fqn. */
-    FQN, 
- /** The sid. */
- SID, 
- /** The both. */
- BOTH, 
- /** The none. */
- NONE;
+    FQN,
+    /** The sid. */
+    SID,
+    /** The both. */
+    BOTH,
+    /** The none. */
+    NONE;
 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
@@ -24,18 +24,18 @@ public class WindowsAccount implements Serializable {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
-    
+
     /** The sid string. */
-    private final String            sidString;
-    
+    private final String      sidString;
+
     /** The fqn. */
-    private final String            fqn;
-    
+    private final String      fqn;
+
     /** The name. */
-    private final String            name;
-    
+    private final String      name;
+
     /** The domain. */
-    private final String            domain;
+    private final String      domain;
 
     /**
      * Instantiates a new windows account.
@@ -86,7 +86,9 @@ public class WindowsAccount implements Serializable {
         return this.domain;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -103,7 +105,9 @@ public class WindowsAccount implements Serializable {
         return ((WindowsAccount) o).getSidString().equals(this.getSidString());
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.lang.Object#hashCode()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
@@ -88,7 +88,6 @@ public class WindowsAccount implements Serializable {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -107,7 +106,6 @@ public class WindowsAccount implements Serializable {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.lang.Object#hashCode()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
@@ -83,7 +83,6 @@ public class WindowsAccountImpl implements IWindowsAccount {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAccount#getFqn()
      */
     @Override
@@ -103,7 +102,6 @@ public class WindowsAccountImpl implements IWindowsAccount {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAccount#getSidString()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
@@ -81,7 +81,9 @@ public class WindowsAccountImpl implements IWindowsAccount {
         return this.account.domain;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAccount#getFqn()
      */
     @Override
@@ -99,7 +101,9 @@ public class WindowsAccountImpl implements IWindowsAccount {
         return this.account.name;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAccount#getSidString()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
@@ -71,7 +71,9 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
                 .build();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#acceptSecurityToken(java.lang.String, byte[], java.lang.String)
      */
     @Override
@@ -145,7 +147,9 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
         return sc;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#getCurrentComputer()
      */
     @Override
@@ -157,7 +161,9 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#getDomains()
      */
     @Override
@@ -170,8 +176,11 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
         return domains.toArray(new IWindowsDomain[0]);
     }
 
-    /* (non-Javadoc)
-     * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUser(java.lang.String, java.lang.String, java.lang.String)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUser(java.lang.String, java.lang.String,
+     * java.lang.String)
      */
     @Override
     public IWindowsIdentity logonDomainUser(final String username, final String domain, final String password) {
@@ -179,8 +188,11 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
                 WinBase.LOGON32_PROVIDER_DEFAULT);
     }
 
-    /* (non-Javadoc)
-     * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUserEx(java.lang.String, java.lang.String, java.lang.String, int, int)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUserEx(java.lang.String, java.lang.String,
+     * java.lang.String, int, int)
      */
     @Override
     public IWindowsIdentity logonDomainUserEx(final String username, final String domain, final String password,
@@ -192,7 +204,9 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
         return new WindowsIdentityImpl(phUser.getValue());
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#logonUser(java.lang.String, java.lang.String)
      */
     @Override
@@ -206,7 +220,9 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
         return this.logonDomainUser(username, null, password);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#lookupAccount(java.lang.String)
      */
     @Override
@@ -214,7 +230,9 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
         return new WindowsAccountImpl(username);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#resetSecurityToken(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
@@ -73,7 +73,6 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#acceptSecurityToken(java.lang.String, byte[], java.lang.String)
      */
     @Override
@@ -149,7 +148,6 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#getCurrentComputer()
      */
     @Override
@@ -163,7 +161,6 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#getDomains()
      */
     @Override
@@ -178,7 +175,6 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUser(java.lang.String, java.lang.String,
      * java.lang.String)
      */
@@ -190,7 +186,6 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUserEx(java.lang.String, java.lang.String,
      * java.lang.String, int, int)
      */
@@ -206,7 +201,6 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#logonUser(java.lang.String, java.lang.String)
      */
     @Override
@@ -222,7 +216,6 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#lookupAccount(java.lang.String)
      */
     @Override
@@ -232,7 +225,6 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#resetSecurityToken(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
@@ -31,7 +31,7 @@ public class WindowsComputerImpl implements IWindowsComputer {
 
     /** The computer name. */
     private final String computerName;
-    
+
     /** The domain name. */
     private final String domainName;
 
@@ -46,7 +46,9 @@ public class WindowsComputerImpl implements IWindowsComputer {
         this.domainName = Netapi32Util.getDomainName(newComputerName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsComputer#getComputerName()
      */
     @Override
@@ -54,7 +56,9 @@ public class WindowsComputerImpl implements IWindowsComputer {
         return this.computerName;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsComputer#getGroups()
      */
     @Override
@@ -67,7 +71,9 @@ public class WindowsComputerImpl implements IWindowsComputer {
         return groupNames.toArray(new String[0]);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsComputer#getJoinStatus()
      */
     @Override
@@ -87,7 +93,9 @@ public class WindowsComputerImpl implements IWindowsComputer {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsComputer#getMemberOf()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
@@ -48,7 +48,6 @@ public class WindowsComputerImpl implements IWindowsComputer {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsComputer#getComputerName()
      */
     @Override
@@ -58,7 +57,6 @@ public class WindowsComputerImpl implements IWindowsComputer {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsComputer#getGroups()
      */
     @Override
@@ -73,7 +71,6 @@ public class WindowsComputerImpl implements IWindowsComputer {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsComputer#getJoinStatus()
      */
     @Override
@@ -95,7 +92,6 @@ public class WindowsComputerImpl implements IWindowsComputer {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsComputer#getMemberOf()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
@@ -31,19 +31,19 @@ import com.sun.jna.platform.win32.WinError;
 public class WindowsCredentialsHandleImpl implements IWindowsCredentialsHandle {
 
     /** The principal name. */
-    private final String     principalName;
-    
+    private final String principalName;
+
     /** The credentials type. */
-    private final int        credentialsType;
-    
+    private final int    credentialsType;
+
     /** The security package. */
-    private final String     securityPackage;
-    
+    private final String securityPackage;
+
     /** The handle. */
-    private CredHandle handle;
-    
+    private CredHandle   handle;
+
     /** The client lifetime. */
-    private TimeStamp  clientLifetime;
+    private TimeStamp    clientLifetime;
 
     /**
      * A new Windows credentials handle.

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
@@ -107,7 +107,6 @@ public class WindowsDomainImpl implements IWindowsDomain {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsDomain#getFqn()
      */
     @Override
@@ -117,7 +116,6 @@ public class WindowsDomainImpl implements IWindowsDomain {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsDomain#getTrustDirectionString()
      */
     @Override
@@ -127,7 +125,6 @@ public class WindowsDomainImpl implements IWindowsDomain {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsDomain#getTrustTypeString()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
@@ -28,42 +28,42 @@ public class WindowsDomainImpl implements IWindowsDomain {
      * The Enum TrustDirection.
      */
     private enum TrustDirection {
-        
+
         /** The inbound. */
-        INBOUND, 
- /** The outbound. */
- OUTBOUND, 
- /** The bidirectional. */
- BIDIRECTIONAL
+        INBOUND,
+        /** The outbound. */
+        OUTBOUND,
+        /** The bidirectional. */
+        BIDIRECTIONAL
     }
 
     /**
      * The Enum TrustType.
      */
     private enum TrustType {
-        
+
         /** The tree root. */
-        TREE_ROOT, 
- /** The parent child. */
- PARENT_CHILD, 
- /** The cross link. */
- CROSS_LINK, 
- /** The external. */
- EXTERNAL, 
- /** The forest. */
- FOREST, 
- /** The kerberos. */
- KERBEROS, 
- /** The unknown. */
- UNKNOWN
+        TREE_ROOT,
+        /** The parent child. */
+        PARENT_CHILD,
+        /** The cross link. */
+        CROSS_LINK,
+        /** The external. */
+        EXTERNAL,
+        /** The forest. */
+        FOREST,
+        /** The kerberos. */
+        KERBEROS,
+        /** The unknown. */
+        UNKNOWN
     }
 
     /** The fqn. */
     private String         fqn;
-    
+
     /** The trust direction. */
     private TrustDirection trustDirection = TrustDirection.BIDIRECTIONAL;
-    
+
     /** The trust type. */
     private TrustType      trustType      = TrustType.UNKNOWN;
 
@@ -105,7 +105,9 @@ public class WindowsDomainImpl implements IWindowsDomain {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsDomain#getFqn()
      */
     @Override
@@ -113,7 +115,9 @@ public class WindowsDomainImpl implements IWindowsDomain {
         return this.fqn;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsDomain#getTrustDirectionString()
      */
     @Override
@@ -121,7 +125,9 @@ public class WindowsDomainImpl implements IWindowsDomain {
         return this.trustDirection.toString();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsDomain#getTrustTypeString()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
@@ -39,7 +39,9 @@ public class WindowsIdentityImpersonationContextImpl implements IWindowsImperson
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsImpersonationContext#revertToSelf()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
@@ -41,7 +41,6 @@ public class WindowsIdentityImpersonationContextImpl implements IWindowsImperson
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsImpersonationContext#revertToSelf()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
@@ -34,13 +34,13 @@ import com.sun.jna.platform.win32.WinNT.WELL_KNOWN_SID_TYPE;
 public class WindowsIdentityImpl implements IWindowsIdentity {
 
     /** The windows identity. */
-    private final HANDLE    windowsIdentity;
-    
+    private final HANDLE windowsIdentity;
+
     /** The user groups. */
-    private Account[] userGroups;
-    
+    private Account[]    userGroups;
+
     /** The windows account. */
-    private Account   windowsAccount;
+    private Account      windowsAccount;
 
     /**
      * Instantiates a new windows identity impl.
@@ -76,7 +76,9 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
         return this.userGroups.clone();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#getFqn()
      */
     @Override
@@ -84,7 +86,9 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
         return this.getWindowsAccount().fqn;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#getGroups()
      */
     @Override
@@ -101,7 +105,9 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
         return result.toArray(new IWindowsAccount[0]);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#getSid()
      */
     @Override
@@ -109,7 +115,9 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
         return this.getWindowsAccount().sid;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#getSidString()
      */
     @Override
@@ -117,7 +125,9 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
         return this.getWindowsAccount().sidString;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#dispose()
      */
     @Override
@@ -127,7 +137,9 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#impersonate()
      */
     @Override
@@ -135,7 +147,9 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
         return new WindowsIdentityImpersonationContextImpl(this.windowsIdentity);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#isGuest()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
@@ -78,7 +78,6 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#getFqn()
      */
     @Override
@@ -88,7 +87,6 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#getGroups()
      */
     @Override
@@ -107,7 +105,6 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#getSid()
      */
     @Override
@@ -117,7 +114,6 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#getSidString()
      */
     @Override
@@ -127,7 +123,6 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#dispose()
      */
     @Override
@@ -139,7 +134,6 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#impersonate()
      */
     @Override
@@ -149,7 +143,6 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#isGuest()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
@@ -45,7 +45,9 @@ public class WindowsSecurityContextImpersonationContextImpl implements IWindowsI
         this.ctx = newCtx;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsImpersonationContext#revertToSelf()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
@@ -47,7 +47,6 @@ public class WindowsSecurityContextImpersonationContextImpl implements IWindowsI
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsImpersonationContext#revertToSelf()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
@@ -37,26 +37,28 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /** The principal name. */
     private String         principalName;
-    
+
     /** The security package. */
     private String         securityPackage;
-    
+
     /** The token. */
     private SecBufferDesc  token;
-    
+
     /** The ctx. */
     private CtxtHandle     ctx;
-    
+
     /** The attr. */
     private IntByReference attr;
-    
+
     /** The credentials. */
     private CredHandle     credentials;
-    
+
     /** The continue flag. */
     private boolean        continueFlag;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#impersonate()
      */
     @Override
@@ -64,7 +66,9 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
         return new WindowsSecurityContextImpersonationContextImpl(this.ctx);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getIdentity()
      */
     @Override
@@ -77,7 +81,9 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
         return new WindowsIdentityImpl(phContextToken.getValue());
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getSecurityPackage()
      */
     @Override
@@ -85,7 +91,9 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
         return this.securityPackage;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getToken()
      */
     @Override
@@ -117,8 +125,11 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
         }
     }
 
-    /* (non-Javadoc)
-     * @see waffle.windows.auth.IWindowsSecurityContext#initialize(com.sun.jna.platform.win32.Sspi.CtxtHandle, com.sun.jna.platform.win32.Sspi.SecBufferDesc, java.lang.String)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.windows.auth.IWindowsSecurityContext#initialize(com.sun.jna.platform.win32.Sspi.CtxtHandle,
+     * com.sun.jna.platform.win32.Sspi.SecBufferDesc, java.lang.String)
      */
     @Override
     public void initialize(final CtxtHandle continueCtx, final SecBufferDesc continueToken, final String targetName) {
@@ -147,7 +158,9 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
         } while (rc == WinError.SEC_E_INSUFFICIENT_MEMORY);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#dispose()
      */
     @Override
@@ -173,7 +186,9 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
         return false;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getPrincipalName()
      */
     @Override
@@ -191,7 +206,9 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
         this.principalName = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getHandle()
      */
     @Override
@@ -239,7 +256,9 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
         this.ctx = phNewServerContext;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#isContinue()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
@@ -58,7 +58,6 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#impersonate()
      */
     @Override
@@ -68,7 +67,6 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getIdentity()
      */
     @Override
@@ -83,7 +81,6 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getSecurityPackage()
      */
     @Override
@@ -93,7 +90,6 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getToken()
      */
     @Override
@@ -127,7 +123,6 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#initialize(com.sun.jna.platform.win32.Sspi.CtxtHandle,
      * com.sun.jna.platform.win32.Sspi.SecBufferDesc, java.lang.String)
      */
@@ -160,7 +155,6 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#dispose()
      */
     @Override
@@ -188,7 +182,6 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getPrincipalName()
      */
     @Override
@@ -208,7 +201,6 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getHandle()
      */
     @Override
@@ -258,7 +250,6 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#isContinue()
      */
     @Override

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/RolePrincipalTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/RolePrincipalTests.java
@@ -73,8 +73,10 @@ public class RolePrincipalTests {
     /**
      * Test is serializable.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ClassNotFoundException the class not found exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test
     public void testIsSerializable() throws IOException, ClassNotFoundException {

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UserPrincipalTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UserPrincipalTests.java
@@ -73,8 +73,10 @@ public class UserPrincipalTests {
     /**
      * Test is serializable.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ClassNotFoundException the class not found exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test
     public void testIsSerializable() throws IOException, ClassNotFoundException {

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
@@ -49,7 +49,6 @@ public class UsernamePasswordCallbackHandler implements CallbackHandler {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.security.auth.callback.CallbackHandler#handle(javax.security.auth.callback.Callback[])
      */
     @Override

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
@@ -30,22 +30,26 @@ public class UsernamePasswordCallbackHandler implements CallbackHandler {
 
     /** The username. */
     private final String username;
-    
+
     /** The password. */
     private final String password;
 
     /**
      * Instantiates a new username password callback handler.
      *
-     * @param newUserName the new user name
-     * @param newPassword the new password
+     * @param newUserName
+     *            the new user name
+     * @param newPassword
+     *            the new password
      */
     public UsernamePasswordCallbackHandler(final String newUserName, final String newPassword) {
         this.username = newUserName;
         this.password = newPassword;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.security.auth.callback.CallbackHandler#handle(javax.security.auth.callback.Callback[])
      */
     @Override

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
@@ -44,13 +44,13 @@ public class WindowsLoginModuleTest {
 
     /** The login module. */
     private WindowsLoginModule  loginModule;
-    
+
     /** The subject. */
     private Subject             subject;
-    
+
     /** The callback handler. */
     private CallbackHandler     callbackHandler;
-    
+
     /** The options. */
     private Map<String, String> options;
 
@@ -77,7 +77,8 @@ public class WindowsLoginModuleTest {
     /**
      * Commit_no principal.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void commit_noPrincipal() throws LoginException {
@@ -87,7 +88,8 @@ public class WindowsLoginModuleTest {
     /**
      * Commit_subject read only.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test(expected = LoginException.class)
     public void commit_subjectReadOnly() throws LoginException {
@@ -100,7 +102,8 @@ public class WindowsLoginModuleTest {
     /**
      * Commit_success.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void commit_success() throws LoginException {
@@ -112,7 +115,8 @@ public class WindowsLoginModuleTest {
     /**
      * Commit_with debug.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void commit_withDebug() throws LoginException {
@@ -154,7 +158,8 @@ public class WindowsLoginModuleTest {
     /**
      * Login_invalid guest login.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test(expected = LoginException.class)
     public void login_invalidGuestLogin() throws LoginException {
@@ -168,7 +173,8 @@ public class WindowsLoginModuleTest {
     /**
      * Login_null password.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test(expected = LoginException.class)
     public void login_nullPassword() throws LoginException {
@@ -182,9 +188,12 @@ public class WindowsLoginModuleTest {
     /**
      * Login_throw io exception.
      *
-     * @throws LoginException the login exception
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws UnsupportedCallbackException the unsupported callback exception
+     * @throws LoginException
+     *             the login exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws UnsupportedCallbackException
+     *             the unsupported callback exception
      */
     @Test(expected = LoginException.class)
     public void login_throwIOException() throws LoginException, IOException, UnsupportedCallbackException {
@@ -198,9 +207,12 @@ public class WindowsLoginModuleTest {
     /**
      * Login_throw unsupported callback exception.
      *
-     * @throws LoginException the login exception
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws UnsupportedCallbackException the unsupported callback exception
+     * @throws LoginException
+     *             the login exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws UnsupportedCallbackException
+     *             the unsupported callback exception
      */
     @Test(expected = LoginException.class)
     public void login_throwUnsupportedCallbackException() throws LoginException, IOException,
@@ -216,7 +228,8 @@ public class WindowsLoginModuleTest {
     /**
      * Logon_no callback handler.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test(expected = LoginException.class)
     public void logon_noCallbackHandler() throws LoginException {
@@ -226,7 +239,8 @@ public class WindowsLoginModuleTest {
     /**
      * Logout_abort no user.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void logout_abortNoUser() throws LoginException {
@@ -237,7 +251,8 @@ public class WindowsLoginModuleTest {
     /**
      * Logout_no user.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void logout_noUser() throws LoginException {
@@ -248,7 +263,8 @@ public class WindowsLoginModuleTest {
     /**
      * Logout_subject read only.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test(expected = LoginException.class)
     public void logout_subjectReadOnly() throws LoginException {
@@ -260,7 +276,8 @@ public class WindowsLoginModuleTest {
     /**
      * Logout_valid user.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void logout_validUser() throws LoginException {

--- a/Source/JNA/waffle-jna/src/test/java/waffle/servlet/spi/SecurityFilterProviderCollectionTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/servlet/spi/SecurityFilterProviderCollectionTests.java
@@ -28,7 +28,8 @@ public class SecurityFilterProviderCollectionTests {
     /**
      * Test default collection.
      *
-     * @throws ClassNotFoundException the class not found exception
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test
     public void testDefaultCollection() throws ClassNotFoundException {
@@ -42,7 +43,8 @@ public class SecurityFilterProviderCollectionTests {
     /**
      * Test get by class name invalid.
      *
-     * @throws ClassNotFoundException the class not found exception
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test(expected = ClassNotFoundException.class)
     public void testGetByClassNameInvalid() throws ClassNotFoundException {

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/SPNegoMessageTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/SPNegoMessageTests.java
@@ -28,7 +28,7 @@ public class SPNegoMessageTests {
 
     /** The Constant negTokenInitOk. */
     private static final byte[] negTokenInitOk       = { 0x60, 0x76, 0x06, 0x06, 0x2B, 0x06, 0x01, 0x05, 0x05, 0x02 };
-    
+
     /** The Constant negTokenInitTooShort. */
     private static final byte[] negTokenInitTooShort = { 0x60, 0x76, 0x06, 0x06, 0x2B, 0x06, 0x01, 0x05, 0x05 };
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/WaffleInfoTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/WaffleInfoTests.java
@@ -38,7 +38,8 @@ public class WaffleInfoTests {
     /**
      * Test waffle info.
      *
-     * @throws ParserConfigurationException the parser configuration exception
+     * @throws ParserConfigurationException
+     *             the parser configuration exception
      */
     @Test
     public void testWaffleInfo() throws ParserConfigurationException {
@@ -46,8 +47,8 @@ public class WaffleInfoTests {
         final Document info = helper.getWaffleInfo();
 
         // Make sure JNA Version is properly noted
-        Assert.assertEquals(Platform.class.getPackage().getImplementationVersion(),
-                info.getDocumentElement().getAttribute("jna"));
+        Assert.assertEquals(Platform.class.getPackage().getImplementationVersion(), info.getDocumentElement()
+                .getAttribute("jna"));
 
         // waffle auth currentUser computer
         final Node node = info.getDocumentElement().getFirstChild().getFirstChild().getNextSibling();

--- a/Source/JNA/waffle-shiro/format.xml
+++ b/Source/JNA/waffle-shiro/format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/Source/JNA/waffle-shiro/pom.xml
+++ b/Source/JNA/waffle-shiro/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
         <shiro.version>1.2.3</shiro.version>

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/AbstractWaffleRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/AbstractWaffleRealm.java
@@ -51,7 +51,6 @@ public abstract class AbstractWaffleRealm extends AuthorizingRealm {
 
     /*
      * (non-Javadoc)
-     * 
      * @see
      * org.apache.shiro.realm.AuthenticatingRealm#doGetAuthenticationInfo(org.apache.shiro.authc.AuthenticationToken)
      */
@@ -110,7 +109,6 @@ public abstract class AbstractWaffleRealm extends AuthorizingRealm {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.shiro.realm.AuthorizingRealm#doGetAuthorizationInfo(org.apache.shiro.subject.PrincipalCollection)
      */
     @Override

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/AbstractWaffleRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/AbstractWaffleRealm.java
@@ -39,18 +39,21 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
  * for subclasses to define by implementing the {@link #buildAuthorizationInfo} method.
  */
 public abstract class AbstractWaffleRealm extends AuthorizingRealm {
-    
+
     /** The Constant LOGGER. */
     private static final Logger  LOGGER     = LoggerFactory.getLogger(AbstractWaffleRealm.class);
-    
+
     /** The Constant REALM_NAME. */
     private static final String  REALM_NAME = "WAFFLE";
 
     /** The provider. */
     private IWindowsAuthProvider provider   = new WindowsAuthProviderImpl();
 
-    /* (non-Javadoc)
-     * @see org.apache.shiro.realm.AuthenticatingRealm#doGetAuthenticationInfo(org.apache.shiro.authc.AuthenticationToken)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.apache.shiro.realm.AuthenticatingRealm#doGetAuthenticationInfo(org.apache.shiro.authc.AuthenticationToken)
      */
     @Override
     protected final AuthenticationInfo doGetAuthenticationInfo(final AuthenticationToken authToken) {
@@ -105,7 +108,9 @@ public abstract class AbstractWaffleRealm extends AuthorizingRealm {
         return authenticationInfo;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.shiro.realm.AuthorizingRealm#doGetAuthorizationInfo(org.apache.shiro.subject.PrincipalCollection)
      */
     @Override

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/GroupMappingWaffleRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/GroupMappingWaffleRealm.java
@@ -28,7 +28,7 @@ import org.apache.shiro.authz.SimpleAuthorizationInfo;
  * {@link org.apache.shiro.authz.permission.RolePermissionResolver}.
  */
 public class GroupMappingWaffleRealm extends AbstractWaffleRealm {
-    
+
     /** The group roles map. */
     private final Map<String, String> groupRolesMap = new HashMap<>();
 

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/WaffleFqnPrincipal.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/WaffleFqnPrincipal.java
@@ -68,7 +68,6 @@ public class WaffleFqnPrincipal implements Serializable {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -81,7 +80,6 @@ public class WaffleFqnPrincipal implements Serializable {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.lang.Object#hashCode()
      */
     @Override
@@ -91,7 +89,6 @@ public class WaffleFqnPrincipal implements Serializable {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.lang.Object#toString()
      */
     @Override

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/WaffleFqnPrincipal.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/WaffleFqnPrincipal.java
@@ -25,13 +25,13 @@ import waffle.windows.auth.IWindowsIdentity;
  * The Class WaffleFqnPrincipal.
  */
 public class WaffleFqnPrincipal implements Serializable {
-    
+
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1;
-    
+
     /** The fqn. */
     private final String      fqn;
-    
+
     /** The group fqns. */
     private final Set<String> groupFqns        = new HashSet<>();
 
@@ -66,7 +66,9 @@ public class WaffleFqnPrincipal implements Serializable {
         return Collections.unmodifiableSet(this.groupFqns);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -77,7 +79,9 @@ public class WaffleFqnPrincipal implements Serializable {
         return false;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.lang.Object#hashCode()
      */
     @Override
@@ -85,7 +89,9 @@ public class WaffleFqnPrincipal implements Serializable {
         return this.fqn.hashCode();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.lang.Object#toString()
      */
     @Override

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/dynamic/DynamicAuthenticationFilter.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/dynamic/DynamicAuthenticationFilter.java
@@ -120,7 +120,6 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
 
         /*
          * (non-Javadoc)
-         * 
          * @see waffle.shiro.negotiate.NegotiateAuthenticationFilter#onAccessDenied(javax.servlet.ServletRequest,
          * javax.servlet.ServletResponse)
          */
@@ -131,7 +130,6 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
 
         /*
          * (non-Javadoc)
-         * 
          * @see
          * waffle.shiro.negotiate.NegotiateAuthenticationFilter#onLoginSuccess(org.apache.shiro.authc.AuthenticationToken
          * , org.apache.shiro.subject.Subject, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
@@ -166,7 +164,6 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
 
         /*
          * (non-Javadoc)
-         * 
          * @see org.apache.shiro.web.filter.authc.FormAuthenticationFilter#onAccessDenied(javax.servlet.ServletRequest,
          * javax.servlet.ServletResponse)
          */
@@ -177,7 +174,6 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
 
         /*
          * (non-Javadoc)
-         * 
          * @see org.apache.shiro.web.filter.authc.FormAuthenticationFilter#onLoginSuccess(org.apache.shiro.authc.
          * AuthenticationToken, org.apache.shiro.subject.Subject, javax.servlet.ServletRequest,
          * javax.servlet.ServletResponse)

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/dynamic/DynamicAuthenticationFilter.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/dynamic/DynamicAuthenticationFilter.java
@@ -96,7 +96,7 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
 
     /** The Constant PARAM_NAME_AUTHTYPE. */
     public static final String  PARAM_NAME_AUTHTYPE          = "authType";
-    
+
     /** The Constant PARAM_VAL_AUTHTYPE_NEGOTIATE. */
     public static final String  PARAM_VAL_AUTHTYPE_NEGOTIATE = "j_negotiate";
 
@@ -118,16 +118,23 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
             this.parent = newParent;
         }
 
-        /* (non-Javadoc)
-         * @see waffle.shiro.negotiate.NegotiateAuthenticationFilter#onAccessDenied(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
+        /*
+         * (non-Javadoc)
+         * 
+         * @see waffle.shiro.negotiate.NegotiateAuthenticationFilter#onAccessDenied(javax.servlet.ServletRequest,
+         * javax.servlet.ServletResponse)
          */
         @Override
         public boolean onAccessDenied(final ServletRequest request, final ServletResponse response) throws Exception {
             return super.onAccessDenied(request, response);
         }
 
-        /* (non-Javadoc)
-         * @see waffle.shiro.negotiate.NegotiateAuthenticationFilter#onLoginSuccess(org.apache.shiro.authc.AuthenticationToken, org.apache.shiro.subject.Subject, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
+        /*
+         * (non-Javadoc)
+         * 
+         * @see
+         * waffle.shiro.negotiate.NegotiateAuthenticationFilter#onLoginSuccess(org.apache.shiro.authc.AuthenticationToken
+         * , org.apache.shiro.subject.Subject, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
          */
         @Override
         protected boolean onLoginSuccess(final AuthenticationToken token, final Subject subject,
@@ -157,16 +164,23 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
             this.parent = newParent;
         }
 
-        /* (non-Javadoc)
-         * @see org.apache.shiro.web.filter.authc.FormAuthenticationFilter#onAccessDenied(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
+        /*
+         * (non-Javadoc)
+         * 
+         * @see org.apache.shiro.web.filter.authc.FormAuthenticationFilter#onAccessDenied(javax.servlet.ServletRequest,
+         * javax.servlet.ServletResponse)
          */
         @Override
         public boolean onAccessDenied(final ServletRequest request, final ServletResponse response) throws Exception {
             return super.onAccessDenied(request, response);
         }
 
-        /* (non-Javadoc)
-         * @see org.apache.shiro.web.filter.authc.FormAuthenticationFilter#onLoginSuccess(org.apache.shiro.authc.AuthenticationToken, org.apache.shiro.subject.Subject, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
+        /*
+         * (non-Javadoc)
+         * 
+         * @see org.apache.shiro.web.filter.authc.FormAuthenticationFilter#onLoginSuccess(org.apache.shiro.authc.
+         * AuthenticationToken, org.apache.shiro.subject.Subject, javax.servlet.ServletRequest,
+         * javax.servlet.ServletResponse)
          */
         @Override
         protected boolean onLoginSuccess(final AuthenticationToken token, final Subject subject,

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/AuthenticationInProgressException.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/AuthenticationInProgressException.java
@@ -27,7 +27,7 @@ import org.apache.shiro.authc.AuthenticationException;
  * @since 1.0.0
  */
 public class AuthenticationInProgressException extends AuthenticationException {
-    
+
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 2684886728102100988L;
 }

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationFilter.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationFilter.java
@@ -89,8 +89,8 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
 
     /**
      * Sets the request parameter name to look for when acquiring the rememberMe boolean value. Unless overridden by
-     * calling this method, the default is <code>rememberMe</code>.
-     * <br><br>
+     * calling this method, the default is <code>rememberMe</code>. <br>
+     * <br>
      * RememberMe will be <code>true</code> if the parameter value equals any of those supported by
      * {@link org.apache.shiro.web.util.WebUtils#isTrue(javax.servlet.ServletRequest, String)
      * WebUtils.isTrue(request,value)}, <code>false</code> otherwise.
@@ -102,7 +102,9 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
         this.rememberMeParam = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.shiro.web.filter.authc.AuthenticatingFilter#isRememberMe(javax.servlet.ServletRequest)
      */
     @Override
@@ -110,8 +112,11 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
         return WebUtils.isTrue(request, this.getRememberMeParam());
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.shiro.web.filter.authc.AuthenticatingFilter#createToken(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.shiro.web.filter.authc.AuthenticatingFilter#createToken(javax.servlet.ServletRequest,
+     * javax.servlet.ServletResponse)
      */
     @Override
     protected AuthenticationToken createToken(final ServletRequest request, final ServletResponse response) {
@@ -128,8 +133,8 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
         final AuthorizationHeader authorizationHeader = new AuthorizationHeader((HttpServletRequest) request);
         final boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
 
-        NegotiateAuthenticationFilter.LOGGER.debug("security package: {}, connection id: {}, ntlmPost: {}", securityPackage, connectionId,
-                Boolean.valueOf(ntlmPost));
+        NegotiateAuthenticationFilter.LOGGER.debug("security package: {}, connection id: {}, ntlmPost: {}",
+                securityPackage, connectionId, Boolean.valueOf(ntlmPost));
 
         final boolean rememberMe = this.isRememberMe(request);
         final String host = this.getHost(request);
@@ -137,8 +142,12 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
         return new NegotiateToken(inToken, new byte[0], connectionId, securityPackage, ntlmPost, rememberMe, host);
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.shiro.web.filter.authc.AuthenticatingFilter#onLoginSuccess(org.apache.shiro.authc.AuthenticationToken, org.apache.shiro.subject.Subject, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.apache.shiro.web.filter.authc.AuthenticatingFilter#onLoginSuccess(org.apache.shiro.authc.AuthenticationToken,
+     * org.apache.shiro.subject.Subject, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override
     protected boolean onLoginSuccess(final AuthenticationToken token, final Subject subject,
@@ -147,8 +156,12 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.shiro.web.filter.authc.AuthenticatingFilter#onLoginFailure(org.apache.shiro.authc.AuthenticationToken, org.apache.shiro.authc.AuthenticationException, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.apache.shiro.web.filter.authc.AuthenticatingFilter#onLoginFailure(org.apache.shiro.authc.AuthenticationToken,
+     * org.apache.shiro.authc.AuthenticationException, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override
     protected boolean onLoginFailure(final AuthenticationToken token, final AuthenticationException e,
@@ -201,8 +214,11 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
         this.failureKeyAttribute = value;
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.shiro.web.filter.AccessControlFilter#onAccessDenied(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.shiro.web.filter.AccessControlFilter#onAccessDenied(javax.servlet.ServletRequest,
+     * javax.servlet.ServletResponse)
      */
     @Override
     protected boolean onAccessDenied(final ServletRequest request, final ServletResponse response) throws Exception {
@@ -212,7 +228,8 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
         if (this.isLoginAttempt(request)) {
             loggedIn = this.executeLogin(request, response);
         } else {
-            NegotiateAuthenticationFilter.LOGGER.debug("authorization required, supported protocols: {}", NegotiateAuthenticationFilter.PROTOCOLS);
+            NegotiateAuthenticationFilter.LOGGER.debug("authorization required, supported protocols: {}",
+                    NegotiateAuthenticationFilter.PROTOCOLS);
             this.sendChallengeInitiateNegotiate(response);
         }
         return loggedIn;

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationFilter.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationFilter.java
@@ -14,8 +14,10 @@
 package waffle.shiro.negotiate;
 
 /**
- * Derived from net.skorgenes.security.jsecurity.negotiate.NegotiateAuthenticationFilter.
- * see: https://bitbucket.org/lothor/shiro-negotiate/src/7b25efde130b9cbcacf579b3f926c532d919aa23/src/main/java/net/skorgenes/security/jsecurity/negotiate/NegotiateAuthenticationFilter.java?at=default
+ * Derived from net.skorgenes.security.jsecurity.negotiate.NegotiateAuthenticationFilter. see:
+ * https://bitbucket.org/lothor
+ * /shiro-negotiate/src/7b25efde130b9cbcacf579b3f926c532d919aa23/src/main/java/net/skorgenes/
+ * security/jsecurity/negotiate/NegotiateAuthenticationFilter.java?at=default
  *
  * @author Dan Rollo
  */
@@ -104,7 +106,6 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.shiro.web.filter.authc.AuthenticatingFilter#isRememberMe(javax.servlet.ServletRequest)
      */
     @Override
@@ -114,7 +115,6 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.shiro.web.filter.authc.AuthenticatingFilter#createToken(javax.servlet.ServletRequest,
      * javax.servlet.ServletResponse)
      */
@@ -144,7 +144,6 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see
      * org.apache.shiro.web.filter.authc.AuthenticatingFilter#onLoginSuccess(org.apache.shiro.authc.AuthenticationToken,
      * org.apache.shiro.subject.Subject, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
@@ -158,7 +157,6 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see
      * org.apache.shiro.web.filter.authc.AuthenticatingFilter#onLoginFailure(org.apache.shiro.authc.AuthenticationToken,
      * org.apache.shiro.authc.AuthenticationException, javax.servlet.ServletRequest, javax.servlet.ServletResponse)
@@ -216,7 +214,6 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.shiro.web.filter.AccessControlFilter#onAccessDenied(javax.servlet.ServletRequest,
      * javax.servlet.ServletResponse)
      */

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationRealm.java
@@ -14,8 +14,10 @@
 package waffle.shiro.negotiate;
 
 /**
- * Derived from net.skorgenes.security.jsecurity.negotiate.NegotiateAuthenticationFilter.
- * see: https://bitbucket.org/lothor/shiro-negotiate/src/7b25efde130b/src/main/java/net/skorgenes/security/jsecurity/negotiate/NegotiateAuthenticationRealm.java?at=default
+ * Derived from net.skorgenes.security.jsecurity.negotiate.NegotiateAuthenticationFilter. see:
+ * https://bitbucket.org/lothor
+ * /shiro-negotiate/src/7b25efde130b/src/main/java/net/skorgenes/security/jsecurity/negotiate
+ * /NegotiateAuthenticationRealm.java?at=default
  *
  * @author Dan Rollo
  */
@@ -59,7 +61,6 @@ public class NegotiateAuthenticationRealm extends AuthenticatingRealm {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.shiro.realm.AuthenticatingRealm#supports(org.apache.shiro.authc.AuthenticationToken)
      */
     @Override
@@ -69,7 +70,6 @@ public class NegotiateAuthenticationRealm extends AuthenticatingRealm {
 
     /*
      * (non-Javadoc)
-     * 
      * @see
      * org.apache.shiro.realm.AuthenticatingRealm#doGetAuthenticationInfo(org.apache.shiro.authc.AuthenticationToken)
      */

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationRealm.java
@@ -57,7 +57,9 @@ public class NegotiateAuthenticationRealm extends AuthenticatingRealm {
         this.windowsAuthProvider = new WindowsAuthProviderImpl();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.shiro.realm.AuthenticatingRealm#supports(org.apache.shiro.authc.AuthenticationToken)
      */
     @Override
@@ -65,8 +67,11 @@ public class NegotiateAuthenticationRealm extends AuthenticatingRealm {
         return token instanceof NegotiateToken;
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.shiro.realm.AuthenticatingRealm#doGetAuthenticationInfo(org.apache.shiro.authc.AuthenticationToken)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.apache.shiro.realm.AuthenticatingRealm#doGetAuthenticationInfo(org.apache.shiro.authc.AuthenticationToken)
      */
     @Override
     protected AuthenticationInfo doGetAuthenticationInfo(final AuthenticationToken t) {
@@ -91,7 +96,8 @@ public class NegotiateAuthenticationRealm extends AuthenticatingRealm {
         final byte[] continueTokenBytes = securityContext.getToken();
         token.setOut(continueTokenBytes);
         if (continueTokenBytes != null) {
-            NegotiateAuthenticationRealm.LOGGER.debug("continue token bytes: {}", Integer.valueOf(continueTokenBytes.length));
+            NegotiateAuthenticationRealm.LOGGER.debug("continue token bytes: {}",
+                    Integer.valueOf(continueTokenBytes.length));
         } else {
             NegotiateAuthenticationRealm.LOGGER.debug("no continue token bytes");
         }
@@ -103,7 +109,8 @@ public class NegotiateAuthenticationRealm extends AuthenticatingRealm {
         final IWindowsIdentity windowsIdentity = securityContext.getIdentity();
         securityContext.dispose();
 
-        NegotiateAuthenticationRealm.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+        NegotiateAuthenticationRealm.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(),
+                windowsIdentity.getSidString());
 
         final Principal principal = new WindowsPrincipal(windowsIdentity);
         token.setPrincipal(principal);

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateInfo.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateInfo.java
@@ -35,7 +35,7 @@ import org.apache.shiro.subject.SimplePrincipalCollection;
  * @since 1.0.0
  */
 public class NegotiateInfo implements AuthenticationInfo {
-    
+
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = -1537448549089922914L;
 

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateInfo.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateInfo.java
@@ -14,12 +14,11 @@
 package waffle.shiro.negotiate;
 
 /**
- * Derived from net.skorgenes.security.jsecurity.negotiate.NegotiateToken.
- * see: https://bitbucket.org/lothor/shiro-negotiate/src/7b25efde130b/src/main/java/net/skorgenes/security/jsecurity/negotiate/NegotiateInfo.java?at=default
+ * Derived from net.skorgenes.security.jsecurity.negotiate.NegotiateToken. see:
+ * https://bitbucket.org/lothor/shiro-negotiate
+ * /src/7b25efde130b/src/main/java/net/skorgenes/security/jsecurity/negotiate/NegotiateInfo.java?at=default
  *
- * @author Dan Rollo
- * Date: 1/15/13
- * Time: 11:00 PM
+ * @author Dan Rollo Date: 1/15/13 Time: 11:00 PM
  */
 import javax.security.auth.Subject;
 

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateToken.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateToken.java
@@ -32,7 +32,7 @@ import org.apache.shiro.authc.RememberMeAuthenticationToken;
  * @since 1.0.0
  */
 public class NegotiateToken implements HostAuthenticationToken, RememberMeAuthenticationToken {
-    
+
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1345343228636916781L;
 
@@ -50,10 +50,10 @@ public class NegotiateToken implements HostAuthenticationToken, RememberMeAuthen
 
     /** The connection id. */
     private final String      connectionId;
-    
+
     /** The security package. */
     private final String      securityPackage;
-    
+
     /** The ntlm post. */
     private final boolean     ntlmPost;
 
@@ -125,7 +125,9 @@ public class NegotiateToken implements HostAuthenticationToken, RememberMeAuthen
         return this.ntlmPost;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.shiro.authc.AuthenticationToken#getCredentials()
      */
     @Override
@@ -133,7 +135,9 @@ public class NegotiateToken implements HostAuthenticationToken, RememberMeAuthen
         return this.subject;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.shiro.authc.AuthenticationToken#getPrincipal()
      */
     @Override

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateToken.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateToken.java
@@ -14,8 +14,10 @@
 package waffle.shiro.negotiate;
 
 /**
- * Derived from net.skorgenes.security.jsecurity.negotiate.NegotiateToken.
- * see: https://bitbucket.org/lothor/shiro-negotiate/src/7b25efde130b9cbcacf579b3f926c532d919aa23/src/main/java/net/skorgenes/security/jsecurity/negotiate/NegotiateAuthenticationFilter.java?at=default
+ * Derived from net.skorgenes.security.jsecurity.negotiate.NegotiateToken. see:
+ * https://bitbucket.org/lothor/shiro-negotiate
+ * /src/7b25efde130b9cbcacf579b3f926c532d919aa23/src/main/java/net/skorgenes/
+ * security/jsecurity/negotiate/NegotiateAuthenticationFilter.java?at=default
  *
  * @author Dan Rollo
  */
@@ -127,7 +129,6 @@ public class NegotiateToken implements HostAuthenticationToken, RememberMeAuthen
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.shiro.authc.AuthenticationToken#getCredentials()
      */
     @Override
@@ -137,7 +138,6 @@ public class NegotiateToken implements HostAuthenticationToken, RememberMeAuthen
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.shiro.authc.AuthenticationToken#getPrincipal()
      */
     @Override

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/GroupMappingWaffleRealmTests.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/GroupMappingWaffleRealmTests.java
@@ -34,13 +34,13 @@ import com.sun.jna.platform.win32.Secur32Util;
  * The Class GroupMappingWaffleRealmTests.
  */
 public class GroupMappingWaffleRealmTests {
-    
+
     /** The Constant ROLE_NAME. */
     private static final String     ROLE_NAME = "ShiroUsers";
-    
+
     /** The windows auth provider. */
     private MockWindowsAuthProvider windowsAuthProvider;
-    
+
     /** The realm. */
     private GroupMappingWaffleRealm realm;
 

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/dynamic/DynamicAuthenticationFilterTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/dynamic/DynamicAuthenticationFilterTest.java
@@ -43,7 +43,6 @@ public class DynamicAuthenticationFilterTest {
 
         /*
          * (non-Javadoc)
-         * 
          * @see javax.servlet.ServletRequest#getParameter(java.lang.String)
          */
         @Override

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/dynamic/DynamicAuthenticationFilterTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/dynamic/DynamicAuthenticationFilterTest.java
@@ -41,7 +41,9 @@ public class DynamicAuthenticationFilterTest {
         /** The parameters. */
         private final Map<String, String> parameters = new HashMap<>();
 
-        /* (non-Javadoc)
+        /*
+         * (non-Javadoc)
+         * 
          * @see javax.servlet.ServletRequest#getParameter(java.lang.String)
          */
         @Override

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationFilterTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationFilterTest.java
@@ -58,7 +58,9 @@ public final class NegotiateAuthenticationFilterTest {
         /** The sc. */
         int                             sc;
 
-        /* (non-Javadoc)
+        /*
+         * (non-Javadoc)
+         * 
          * @see javax.servlet.http.HttpServletResponse#addHeader(java.lang.String, java.lang.String)
          */
         @Override
@@ -73,7 +75,9 @@ public final class NegotiateAuthenticationFilterTest {
             this.headersAdded.put(name, values);
         }
 
-        /* (non-Javadoc)
+        /*
+         * (non-Javadoc)
+         * 
          * @see javax.servlet.ServletResponse#flushBuffer()
          */
         @Override
@@ -81,7 +85,9 @@ public final class NegotiateAuthenticationFilterTest {
             this.isFlushed = true;
         }
 
-        /* (non-Javadoc)
+        /*
+         * (non-Javadoc)
+         * 
          * @see javax.servlet.http.HttpServletResponse#sendError(int)
          */
         @Override
@@ -89,7 +95,9 @@ public final class NegotiateAuthenticationFilterTest {
             this.errorCode = sendError;
         }
 
-        /* (non-Javadoc)
+        /*
+         * (non-Javadoc)
+         * 
          * @see javax.servlet.http.HttpServletResponse#setHeader(java.lang.String, java.lang.String)
          */
         @Override
@@ -97,7 +105,9 @@ public final class NegotiateAuthenticationFilterTest {
             this.headers.put(name, value);
         }
 
-        /* (non-Javadoc)
+        /*
+         * (non-Javadoc)
+         * 
          * @see javax.servlet.http.HttpServletResponse#setStatus(int)
          */
         @Override
@@ -109,7 +119,7 @@ public final class NegotiateAuthenticationFilterTest {
 
     /** The neg auth filter. */
     private NegotiateAuthenticationFilter negAuthFilter;
-    
+
     /** The response. */
     private MockServletResponse           response;
 

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationFilterTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationFilterTest.java
@@ -60,7 +60,6 @@ public final class NegotiateAuthenticationFilterTest {
 
         /*
          * (non-Javadoc)
-         * 
          * @see javax.servlet.http.HttpServletResponse#addHeader(java.lang.String, java.lang.String)
          */
         @Override
@@ -77,7 +76,6 @@ public final class NegotiateAuthenticationFilterTest {
 
         /*
          * (non-Javadoc)
-         * 
          * @see javax.servlet.ServletResponse#flushBuffer()
          */
         @Override
@@ -87,7 +85,6 @@ public final class NegotiateAuthenticationFilterTest {
 
         /*
          * (non-Javadoc)
-         * 
          * @see javax.servlet.http.HttpServletResponse#sendError(int)
          */
         @Override
@@ -97,7 +94,6 @@ public final class NegotiateAuthenticationFilterTest {
 
         /*
          * (non-Javadoc)
-         * 
          * @see javax.servlet.http.HttpServletResponse#setHeader(java.lang.String, java.lang.String)
          */
         @Override
@@ -107,7 +103,6 @@ public final class NegotiateAuthenticationFilterTest {
 
         /*
          * (non-Javadoc)
-         * 
          * @see javax.servlet.http.HttpServletResponse#setStatus(int)
          */
         @Override

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationRealmTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationRealmTest.java
@@ -28,7 +28,6 @@ public final class NegotiateAuthenticationRealmTest extends TestCase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see junit.framework.TestCase#setUp()
      */
     @Override

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationRealmTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationRealmTest.java
@@ -26,7 +26,9 @@ public final class NegotiateAuthenticationRealmTest extends TestCase {
     /** The neg auth realm. */
     private NegotiateAuthenticationRealm negAuthRealm;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see junit.framework.TestCase#setUp()
      */
     @Override

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationStrategyTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationStrategyTest.java
@@ -40,7 +40,8 @@ public class NegotiateAuthenticationStrategyTest {
     /**
      * Test after attempt.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test(expected = AuthenticationInProgressException.class)
     public void testAfterAttempt() throws Exception {

--- a/Source/JNA/waffle-spring-security3/format.xml
+++ b/Source/JNA/waffle-spring-security3/format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/Source/JNA/waffle-spring-security3/pom.xml
+++ b/Source/JNA/waffle-spring-security3/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <servlet.version>3.0.1</servlet.version>
         <spring.version>3.2.14.RELEASE</spring.version>

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
@@ -81,19 +81,19 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
  * </pre>
  */
 public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
-    
+
     /** The Constant LOGGER. */
     private static final Logger          LOGGER = LoggerFactory.getLogger(NegotiateSecurityFilter.class);
 
     /** The authentication manager. */
     private AuthenticationManager        authenticationManager;
-    
+
     /** The authentication success handler. */
     private AuthenticationSuccessHandler authenticationSuccessHandler;
-    
+
     /** The authentication failure handler. */
     private AuthenticationFailureHandler authenticationFailureHandler;
-    
+
     /** The access denied handler. */
     private AccessDeniedHandler          accessDeniedHandler;
 
@@ -143,8 +143,11 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
         DelegatingNegotiateSecurityFilter.LOGGER.debug("[waffle.spring.NegotiateSecurityFilter] loaded");
     }
 
-    /* (non-Javadoc)
-     * @see waffle.spring.NegotiateSecurityFilter#setAuthentication(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse, org.springframework.security.core.Authentication)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.spring.NegotiateSecurityFilter#setAuthentication(javax.servlet.http.HttpServletRequest,
+     * javax.servlet.http.HttpServletResponse, org.springframework.security.core.Authentication)
      */
     @Override
     protected boolean setAuthentication(final HttpServletRequest request, final HttpServletResponse response,
@@ -176,7 +179,9 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
         return true;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.spring.NegotiateSecurityFilter#afterPropertiesSet()
      */
     @Override
@@ -205,9 +210,11 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
                 this.authenticationFailureHandler.onAuthenticationFailure(request, response, ae);
                 return;
             } catch (final IOException e) {
-                DelegatingNegotiateSecurityFilter.LOGGER.warn("IOException invoking authenticationFailureHandler: " + e.getMessage());
+                DelegatingNegotiateSecurityFilter.LOGGER.warn("IOException invoking authenticationFailureHandler: "
+                        + e.getMessage());
             } catch (final ServletException e) {
-                DelegatingNegotiateSecurityFilter.LOGGER.warn("ServletException invoking authenticationFailureHandler: " + e.getMessage());
+                DelegatingNegotiateSecurityFilter.LOGGER
+                        .warn("ServletException invoking authenticationFailureHandler: " + e.getMessage());
             }
         }
         super.sendUnauthorized(response, true);
@@ -230,9 +237,11 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
                 this.accessDeniedHandler.handle(request, response, ae);
                 return;
             } catch (final IOException e) {
-                DelegatingNegotiateSecurityFilter.LOGGER.warn("IOException invoking accessDeniedHandler: " + e.getMessage());
+                DelegatingNegotiateSecurityFilter.LOGGER.warn("IOException invoking accessDeniedHandler: "
+                        + e.getMessage());
             } catch (final ServletException e) {
-                DelegatingNegotiateSecurityFilter.LOGGER.warn("ServletException invoking accessDeniedHandler: " + e.getMessage());
+                DelegatingNegotiateSecurityFilter.LOGGER.warn("ServletException invoking accessDeniedHandler: "
+                        + e.getMessage());
             }
         }
         // fallback

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
@@ -145,7 +145,6 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.spring.NegotiateSecurityFilter#setAuthentication(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse, org.springframework.security.core.Authentication)
      */
@@ -181,7 +180,6 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.spring.NegotiateSecurityFilter#afterPropertiesSet()
      */
     @Override

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -31,7 +31,7 @@ public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
     /** The prefix. */
     private final String  prefix;
-    
+
     /** The convert to upper case. */
     private final boolean convertToUpperCase;
 
@@ -48,7 +48,9 @@ public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
         this.convertToUpperCase = newConvertToUpperCase;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.spring.GrantedAuthorityFactory#createGrantedAuthority(waffle.windows.auth.WindowsAccount)
      */
     @Override

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -50,7 +50,6 @@ public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.spring.GrantedAuthorityFactory#createGrantedAuthority(waffle.windows.auth.WindowsAccount)
      */
     @Override

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -46,22 +46,22 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
     /** The Constant LOGGER. */
     private static final Logger              LOGGER                  = LoggerFactory
                                                                              .getLogger(NegotiateSecurityFilter.class);
-    
+
     /** The provider. */
     private SecurityFilterProviderCollection provider;
-    
+
     /** The principal format. */
     private PrincipalFormat                  principalFormat         = PrincipalFormat.FQN;
-    
+
     /** The role format. */
     private PrincipalFormat                  roleFormat              = PrincipalFormat.FQN;
-    
+
     /** The allow guest login. */
     private boolean                          allowGuestLogin         = true;
 
     /** The granted authority factory. */
     private GrantedAuthorityFactory          grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
-    
+
     /** The default granted authority. */
     private GrantedAuthority                 defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
 
@@ -73,8 +73,11 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
         NegotiateSecurityFilter.LOGGER.debug("[waffle.spring.NegotiateSecurityFilter] loaded");
     }
 
-    /* (non-Javadoc)
-     * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse, javax.servlet.FilterChain)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse,
+     * javax.servlet.FilterChain)
      */
     @Override
     public void doFilter(final ServletRequest req, final ServletResponse res, final FilterChain chain)
@@ -114,7 +117,8 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
             }
 
             try {
-                NegotiateSecurityFilter.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+                NegotiateSecurityFilter.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(),
+                        windowsIdentity.getSidString());
 
                 final WindowsPrincipal principal = new WindowsPrincipal(windowsIdentity, this.principalFormat,
                         this.roleFormat);
@@ -161,7 +165,9 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
         return true;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.web.filter.GenericFilterBean#afterPropertiesSet()
      */
     @Override

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -75,7 +75,6 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse,
      * javax.servlet.FilterChain)
      */
@@ -145,7 +144,6 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
     /*
      * Invoked when authentication towards ad was succesful to populate securitycontext Override to add service provider
      * authorization checks.
-     * 
      * @return if security context was set.
      */
     /**
@@ -167,7 +165,6 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.web.filter.GenericFilterBean#afterPropertiesSet()
      */
     @Override

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -48,7 +48,6 @@ public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoi
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.web.AuthenticationEntryPoint#commence(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse, org.springframework.security.core.AuthenticationException)
      */

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -35,7 +35,7 @@ public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoi
 
     /** The Constant LOGGER. */
     private static final Logger              LOGGER = LoggerFactory.getLogger(NegotiateSecurityFilterEntryPoint.class);
-    
+
     /** The provider. */
     private SecurityFilterProviderCollection provider;
 
@@ -46,8 +46,11 @@ public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoi
         NegotiateSecurityFilterEntryPoint.LOGGER.debug("[waffle.spring.NegotiateEntryPoint] loaded");
     }
 
-    /* (non-Javadoc)
-     * @see org.springframework.security.web.AuthenticationEntryPoint#commence(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse, org.springframework.security.core.AuthenticationException)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.springframework.security.web.AuthenticationEntryPoint#commence(javax.servlet.http.HttpServletRequest,
+     * javax.servlet.http.HttpServletResponse, org.springframework.security.core.AuthenticationException)
      */
     @Override
     public void commence(final HttpServletRequest request, final HttpServletResponse response,

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -37,22 +37,22 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
     /** The Constant LOGGER. */
     private static final Logger     LOGGER                  = LoggerFactory
                                                                     .getLogger(WindowsAuthenticationProvider.class);
-    
+
     /** The principal format. */
     private PrincipalFormat         principalFormat         = PrincipalFormat.FQN;
-    
+
     /** The role format. */
     private PrincipalFormat         roleFormat              = PrincipalFormat.FQN;
-    
+
     /** The allow guest login. */
     private boolean                 allowGuestLogin         = true;
-    
+
     /** The auth provider. */
     private IWindowsAuthProvider    authProvider;
-    
+
     /** The granted authority factory. */
     private GrantedAuthorityFactory grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
-    
+
     /** The default granted authority. */
     private GrantedAuthority        defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
 
@@ -63,15 +63,20 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
         WindowsAuthenticationProvider.LOGGER.debug("[waffle.spring.WindowsAuthenticationProvider] loaded");
     }
 
-    /* (non-Javadoc)
-     * @see org.springframework.security.authentication.AuthenticationProvider#authenticate(org.springframework.security.core.Authentication)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.springframework.security.authentication.AuthenticationProvider#authenticate(org.springframework.security.
+     * core.Authentication)
      */
     @Override
     public Authentication authenticate(final Authentication authentication) {
         final UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
         final IWindowsIdentity windowsIdentity = this.authProvider.logonUser(auth.getName(), auth.getCredentials()
                 .toString());
-        WindowsAuthenticationProvider.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+        WindowsAuthenticationProvider.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(),
+                windowsIdentity.getSidString());
 
         if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
             WindowsAuthenticationProvider.LOGGER.warn("guest login disabled: {}", windowsIdentity.getFqn());

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -65,7 +65,6 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see
      * org.springframework.security.authentication.AuthenticationProvider#authenticate(org.springframework.security.
      * core.Authentication)

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -98,7 +98,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#getAuthorities()
      */
     @Override
@@ -108,7 +107,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#getCredentials()
      */
     @Override
@@ -118,7 +116,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#getDetails()
      */
     @Override
@@ -128,7 +125,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#getPrincipal()
      */
     @Override
@@ -138,7 +134,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#isAuthenticated()
      */
     @Override
@@ -148,7 +143,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#setAuthenticated(boolean)
      */
     @Override
@@ -158,7 +152,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.security.Principal#getName()
      */
     @Override

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -49,10 +49,10 @@ public class WindowsAuthenticationToken implements Authentication {
                                                                                           "ROLE_USER");
 
     /** The principal. */
-    private final WindowsPrincipal                    principal;
-    
+    private final WindowsPrincipal              principal;
+
     /** The authorities. */
-    private final Collection<GrantedAuthority>        authorities;
+    private final Collection<GrantedAuthority>  authorities;
 
     /**
      * Convenience constructor that calls
@@ -68,7 +68,8 @@ public class WindowsAuthenticationToken implements Authentication {
      *            The {@link WindowsPrincipal} for which this token exists.
      */
     public WindowsAuthenticationToken(final WindowsPrincipal identity) {
-        this(identity, WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY, WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY);
+        this(identity, WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY,
+                WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY);
     }
 
     /**
@@ -95,7 +96,9 @@ public class WindowsAuthenticationToken implements Authentication {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#getAuthorities()
      */
     @Override
@@ -103,7 +106,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return this.authorities;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#getCredentials()
      */
     @Override
@@ -111,7 +116,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#getDetails()
      */
     @Override
@@ -119,7 +126,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#getPrincipal()
      */
     @Override
@@ -127,7 +136,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return this.principal;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#isAuthenticated()
      */
     @Override
@@ -135,7 +146,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return this.principal != null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#setAuthenticated(boolean)
      */
     @Override
@@ -143,7 +156,9 @@ public class WindowsAuthenticationToken implements Authentication {
         throw new IllegalArgumentException();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.security.Principal#getName()
      */
     @Override

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
@@ -37,7 +37,7 @@ public class NegotiateSecurityFilterEntryPointTests {
 
     /** The entry point. */
     private NegotiateSecurityFilterEntryPoint entryPoint;
-    
+
     /** The ctx. */
     private ApplicationContext                ctx;
 
@@ -62,8 +62,10 @@ public class NegotiateSecurityFilterEntryPointTests {
     /**
      * Test challenge get.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testChallengeGET() throws IOException, ServletException {
@@ -84,8 +86,10 @@ public class NegotiateSecurityFilterEntryPointTests {
     /**
      * Test get set provider.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test(expected = ServletException.class)
     public void testGetSetProvider() throws IOException, ServletException {

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
@@ -54,7 +54,7 @@ public class NegotiateSecurityFilterTests {
 
     /** The filter. */
     private NegotiateSecurityFilter filter;
-    
+
     /** The ctx. */
     private ApplicationContext      ctx;
 
@@ -92,7 +92,8 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test provider.
      *
-     * @throws ClassNotFoundException the class not found exception
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test
     public void testProvider() throws ClassNotFoundException {
@@ -105,8 +106,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test no challenge get.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testNoChallengeGET() throws IOException, ServletException {
@@ -122,8 +125,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test negotiate.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testNegotiate() throws IOException, ServletException {
@@ -159,8 +164,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test unsupported security package passthrough.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testUnsupportedSecurityPackagePassthrough() throws IOException, ServletException {
@@ -176,8 +183,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test guest is disabled.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testGuestIsDisabled() throws IOException, ServletException {
@@ -198,7 +207,8 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test after properties set.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test(expected = ServletException.class)
     public void testAfterPropertiesSet() throws ServletException {

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
@@ -45,7 +45,7 @@ public class WindowsAuthenticationProviderTests {
 
     /** The provider. */
     private WindowsAuthenticationProvider provider;
-    
+
     /** The ctx. */
     private ApplicationContext            ctx;
 

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
@@ -36,7 +36,7 @@ public class WindowsAuthenticationTokenTests {
 
     /** The principal. */
     private WindowsPrincipal           principal;
-    
+
     /** The token. */
     private WindowsAuthenticationToken token;
 

--- a/Source/JNA/waffle-spring-security4/format.xml
+++ b/Source/JNA/waffle-spring-security4/format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/Source/JNA/waffle-spring-security4/pom.xml
+++ b/Source/JNA/waffle-spring-security4/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <thirdparty.dir>../../ThirdParty</thirdparty.dir>
 

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
@@ -81,19 +81,19 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
  * </pre>
  */
 public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
-    
+
     /** The Constant LOGGER. */
     private static final Logger          LOGGER = LoggerFactory.getLogger(NegotiateSecurityFilter.class);
 
     /** The authentication manager. */
     private AuthenticationManager        authenticationManager;
-    
+
     /** The authentication success handler. */
     private AuthenticationSuccessHandler authenticationSuccessHandler;
-    
+
     /** The authentication failure handler. */
     private AuthenticationFailureHandler authenticationFailureHandler;
-    
+
     /** The access denied handler. */
     private AccessDeniedHandler          accessDeniedHandler;
 
@@ -143,8 +143,11 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
         DelegatingNegotiateSecurityFilter.LOGGER.debug("[waffle.spring.NegotiateSecurityFilter] loaded");
     }
 
-    /* (non-Javadoc)
-     * @see waffle.spring.NegotiateSecurityFilter#setAuthentication(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse, org.springframework.security.core.Authentication)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.spring.NegotiateSecurityFilter#setAuthentication(javax.servlet.http.HttpServletRequest,
+     * javax.servlet.http.HttpServletResponse, org.springframework.security.core.Authentication)
      */
     @Override
     protected boolean setAuthentication(final HttpServletRequest request, final HttpServletResponse response,
@@ -176,7 +179,9 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
         return true;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.spring.NegotiateSecurityFilter#afterPropertiesSet()
      */
     @Override
@@ -205,9 +210,11 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
                 this.authenticationFailureHandler.onAuthenticationFailure(request, response, ae);
                 return;
             } catch (final IOException e) {
-                DelegatingNegotiateSecurityFilter.LOGGER.warn("IOException invoking authenticationFailureHandler: " + e.getMessage());
+                DelegatingNegotiateSecurityFilter.LOGGER.warn("IOException invoking authenticationFailureHandler: "
+                        + e.getMessage());
             } catch (final ServletException e) {
-                DelegatingNegotiateSecurityFilter.LOGGER.warn("ServletException invoking authenticationFailureHandler: " + e.getMessage());
+                DelegatingNegotiateSecurityFilter.LOGGER
+                        .warn("ServletException invoking authenticationFailureHandler: " + e.getMessage());
             }
         }
         super.sendUnauthorized(response, true);
@@ -230,9 +237,11 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
                 this.accessDeniedHandler.handle(request, response, ae);
                 return;
             } catch (final IOException e) {
-                DelegatingNegotiateSecurityFilter.LOGGER.warn("IOException invoking accessDeniedHandler: " + e.getMessage());
+                DelegatingNegotiateSecurityFilter.LOGGER.warn("IOException invoking accessDeniedHandler: "
+                        + e.getMessage());
             } catch (final ServletException e) {
-                DelegatingNegotiateSecurityFilter.LOGGER.warn("ServletException invoking accessDeniedHandler: " + e.getMessage());
+                DelegatingNegotiateSecurityFilter.LOGGER.warn("ServletException invoking accessDeniedHandler: "
+                        + e.getMessage());
             }
         }
         // fallback

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/DelegatingNegotiateSecurityFilter.java
@@ -145,7 +145,6 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.spring.NegotiateSecurityFilter#setAuthentication(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse, org.springframework.security.core.Authentication)
      */
@@ -181,7 +180,6 @@ public class DelegatingNegotiateSecurityFilter extends NegotiateSecurityFilter {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.spring.NegotiateSecurityFilter#afterPropertiesSet()
      */
     @Override

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -31,7 +31,7 @@ public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
     /** The prefix. */
     private final String  prefix;
-    
+
     /** The convert to upper case. */
     private final boolean convertToUpperCase;
 
@@ -48,7 +48,9 @@ public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
         this.convertToUpperCase = newConvertToUpperCase;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.spring.GrantedAuthorityFactory#createGrantedAuthority(waffle.windows.auth.WindowsAccount)
      */
     @Override

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -50,7 +50,6 @@ public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.spring.GrantedAuthorityFactory#createGrantedAuthority(waffle.windows.auth.WindowsAccount)
      */
     @Override

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -46,22 +46,22 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
     /** The Constant LOGGER. */
     private static final Logger              LOGGER                  = LoggerFactory
                                                                              .getLogger(NegotiateSecurityFilter.class);
-    
+
     /** The provider. */
     private SecurityFilterProviderCollection provider;
-    
+
     /** The principal format. */
     private PrincipalFormat                  principalFormat         = PrincipalFormat.FQN;
-    
+
     /** The role format. */
     private PrincipalFormat                  roleFormat              = PrincipalFormat.FQN;
-    
+
     /** The allow guest login. */
     private boolean                          allowGuestLogin         = true;
 
     /** The granted authority factory. */
     private GrantedAuthorityFactory          grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
-    
+
     /** The default granted authority. */
     private GrantedAuthority                 defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
 
@@ -73,8 +73,11 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
         NegotiateSecurityFilter.LOGGER.debug("[waffle.spring.NegotiateSecurityFilter] loaded");
     }
 
-    /* (non-Javadoc)
-     * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse, javax.servlet.FilterChain)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse,
+     * javax.servlet.FilterChain)
      */
     @Override
     public void doFilter(final ServletRequest req, final ServletResponse res, final FilterChain chain)
@@ -114,7 +117,8 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
             }
 
             try {
-                NegotiateSecurityFilter.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+                NegotiateSecurityFilter.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(),
+                        windowsIdentity.getSidString());
 
                 final WindowsPrincipal principal = new WindowsPrincipal(windowsIdentity, this.principalFormat,
                         this.roleFormat);
@@ -161,7 +165,9 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
         return true;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.web.filter.GenericFilterBean#afterPropertiesSet()
      */
     @Override

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -75,7 +75,6 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse,
      * javax.servlet.FilterChain)
      */
@@ -145,7 +144,6 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
     /*
      * Invoked when authentication towards ad was succesful to populate securitycontext Override to add service provider
      * authorization checks.
-     * 
      * @return if security context was set.
      */
     /**
@@ -167,7 +165,6 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.web.filter.GenericFilterBean#afterPropertiesSet()
      */
     @Override

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -48,7 +48,6 @@ public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoi
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.web.AuthenticationEntryPoint#commence(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse, org.springframework.security.core.AuthenticationException)
      */

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -35,7 +35,7 @@ public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoi
 
     /** The Constant LOGGER. */
     private static final Logger              LOGGER = LoggerFactory.getLogger(NegotiateSecurityFilterEntryPoint.class);
-    
+
     /** The provider. */
     private SecurityFilterProviderCollection provider;
 
@@ -46,8 +46,11 @@ public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoi
         NegotiateSecurityFilterEntryPoint.LOGGER.debug("[waffle.spring.NegotiateEntryPoint] loaded");
     }
 
-    /* (non-Javadoc)
-     * @see org.springframework.security.web.AuthenticationEntryPoint#commence(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse, org.springframework.security.core.AuthenticationException)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.springframework.security.web.AuthenticationEntryPoint#commence(javax.servlet.http.HttpServletRequest,
+     * javax.servlet.http.HttpServletResponse, org.springframework.security.core.AuthenticationException)
      */
     @Override
     public void commence(final HttpServletRequest request, final HttpServletResponse response,

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -37,22 +37,22 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
     /** The Constant LOGGER. */
     private static final Logger     LOGGER                  = LoggerFactory
                                                                     .getLogger(WindowsAuthenticationProvider.class);
-    
+
     /** The principal format. */
     private PrincipalFormat         principalFormat         = PrincipalFormat.FQN;
-    
+
     /** The role format. */
     private PrincipalFormat         roleFormat              = PrincipalFormat.FQN;
-    
+
     /** The allow guest login. */
     private boolean                 allowGuestLogin         = true;
-    
+
     /** The auth provider. */
     private IWindowsAuthProvider    authProvider;
-    
+
     /** The granted authority factory. */
     private GrantedAuthorityFactory grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
-    
+
     /** The default granted authority. */
     private GrantedAuthority        defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
 
@@ -63,15 +63,20 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
         WindowsAuthenticationProvider.LOGGER.debug("[waffle.spring.WindowsAuthenticationProvider] loaded");
     }
 
-    /* (non-Javadoc)
-     * @see org.springframework.security.authentication.AuthenticationProvider#authenticate(org.springframework.security.core.Authentication)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.springframework.security.authentication.AuthenticationProvider#authenticate(org.springframework.security.
+     * core.Authentication)
      */
     @Override
     public Authentication authenticate(final Authentication authentication) {
         final UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
         final IWindowsIdentity windowsIdentity = this.authProvider.logonUser(auth.getName(), auth.getCredentials()
                 .toString());
-        WindowsAuthenticationProvider.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+        WindowsAuthenticationProvider.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(),
+                windowsIdentity.getSidString());
 
         if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
             WindowsAuthenticationProvider.LOGGER.warn("guest login disabled: {}", windowsIdentity.getFqn());

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -65,7 +65,6 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see
      * org.springframework.security.authentication.AuthenticationProvider#authenticate(org.springframework.security.
      * core.Authentication)

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -49,10 +49,10 @@ public class WindowsAuthenticationToken implements Authentication {
                                                                                           "ROLE_USER");
 
     /** The principal. */
-    private final WindowsPrincipal                    principal;
-    
+    private final WindowsPrincipal              principal;
+
     /** The authorities. */
-    private final Collection<GrantedAuthority>        authorities;
+    private final Collection<GrantedAuthority>  authorities;
 
     /**
      * Convenience constructor that calls
@@ -68,7 +68,8 @@ public class WindowsAuthenticationToken implements Authentication {
      *            the identity
      */
     public WindowsAuthenticationToken(final WindowsPrincipal identity) {
-        this(identity, WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY, WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY);
+        this(identity, WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY,
+                WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY);
     }
 
     /**
@@ -95,7 +96,9 @@ public class WindowsAuthenticationToken implements Authentication {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#getAuthorities()
      */
     @Override
@@ -103,7 +106,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return this.authorities;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#getCredentials()
      */
     @Override
@@ -111,7 +116,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#getDetails()
      */
     @Override
@@ -119,7 +126,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#getPrincipal()
      */
     @Override
@@ -127,7 +136,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return this.principal;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#isAuthenticated()
      */
     @Override
@@ -135,7 +146,9 @@ public class WindowsAuthenticationToken implements Authentication {
         return this.principal != null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.springframework.security.core.Authentication#setAuthenticated(boolean)
      */
     @Override
@@ -143,7 +156,9 @@ public class WindowsAuthenticationToken implements Authentication {
         throw new IllegalArgumentException();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see java.security.Principal#getName()
      */
     @Override

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -98,7 +98,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#getAuthorities()
      */
     @Override
@@ -108,7 +107,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#getCredentials()
      */
     @Override
@@ -118,7 +116,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#getDetails()
      */
     @Override
@@ -128,7 +125,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#getPrincipal()
      */
     @Override
@@ -138,7 +134,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#isAuthenticated()
      */
     @Override
@@ -148,7 +143,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.springframework.security.core.Authentication#setAuthenticated(boolean)
      */
     @Override
@@ -158,7 +152,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     /*
      * (non-Javadoc)
-     * 
      * @see java.security.Principal#getName()
      */
     @Override

--- a/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
+++ b/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
@@ -37,7 +37,7 @@ public class NegotiateSecurityFilterEntryPointTests {
 
     /** The entry point. */
     private NegotiateSecurityFilterEntryPoint entryPoint;
-    
+
     /** The ctx. */
     private ApplicationContext                ctx;
 
@@ -62,8 +62,10 @@ public class NegotiateSecurityFilterEntryPointTests {
     /**
      * Test challenge get.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testChallengeGET() throws IOException, ServletException {
@@ -84,8 +86,10 @@ public class NegotiateSecurityFilterEntryPointTests {
     /**
      * Test get set provider.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test(expected = ServletException.class)
     public void testGetSetProvider() throws IOException, ServletException {

--- a/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
@@ -54,7 +54,7 @@ public class NegotiateSecurityFilterTests {
 
     /** The filter. */
     private NegotiateSecurityFilter filter;
-    
+
     /** The ctx. */
     private ApplicationContext      ctx;
 
@@ -92,7 +92,8 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test provider.
      *
-     * @throws ClassNotFoundException the class not found exception
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test
     public void testProvider() throws ClassNotFoundException {
@@ -105,8 +106,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test no challenge get.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testNoChallengeGET() throws IOException, ServletException {
@@ -122,8 +125,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test negotiate.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testNegotiate() throws IOException, ServletException {
@@ -159,8 +164,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test unsupported security package passthrough.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testUnsupportedSecurityPackagePassthrough() throws IOException, ServletException {
@@ -176,8 +183,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test guest is disabled.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testGuestIsDisabled() throws IOException, ServletException {
@@ -198,7 +207,8 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test after properties set.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test(expected = ServletException.class)
     public void testAfterPropertiesSet() throws ServletException {

--- a/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
+++ b/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
@@ -45,7 +45,7 @@ public class WindowsAuthenticationProviderTests {
 
     /** The provider. */
     private WindowsAuthenticationProvider provider;
-    
+
     /** The ctx. */
     private ApplicationContext            ctx;
 

--- a/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
+++ b/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
@@ -36,7 +36,7 @@ public class WindowsAuthenticationTokenTests {
 
     /** The principal. */
     private WindowsPrincipal           principal;
-    
+
     /** The token. */
     private WindowsAuthenticationToken token;
 

--- a/Source/JNA/waffle-tests/format.xml
+++ b/Source/JNA/waffle-tests/format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/Source/JNA/waffle-tests/pom.xml
+++ b/Source/JNA/waffle-tests/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <servlet.version>2.5</servlet.version>
         <mockito.version>1.10.19</mockito.version>

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
@@ -72,7 +72,6 @@ public class MockWindowsAccount implements IWindowsAccount {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAccount#getDomain()
      */
     @Override
@@ -82,7 +81,6 @@ public class MockWindowsAccount implements IWindowsAccount {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAccount#getFqn()
      */
     @Override
@@ -92,7 +90,6 @@ public class MockWindowsAccount implements IWindowsAccount {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAccount#getName()
      */
     @Override
@@ -102,7 +99,6 @@ public class MockWindowsAccount implements IWindowsAccount {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAccount#getSidString()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
@@ -24,21 +24,21 @@ public class MockWindowsAccount implements IWindowsAccount {
 
     /** The Constant TEST_USER_NAME. */
     public static final String TEST_USER_NAME = "WaffleTestUser";
-    
+
     /** The Constant TEST_PASSWORD. */
     public static final String TEST_PASSWORD  = "!WAFFLEP$$Wrd0";
 
     /** The fqn. */
-    private final String             fqn;
-    
+    private final String       fqn;
+
     /** The name. */
     private String             name;
-    
+
     /** The domain. */
     private String             domain;
-    
+
     /** The sid. */
-    private final String             sid;
+    private final String       sid;
 
     /**
      * Instantiates a new mock windows account.
@@ -70,7 +70,9 @@ public class MockWindowsAccount implements IWindowsAccount {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAccount#getDomain()
      */
     @Override
@@ -78,7 +80,9 @@ public class MockWindowsAccount implements IWindowsAccount {
         return this.domain;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAccount#getFqn()
      */
     @Override
@@ -86,7 +90,9 @@ public class MockWindowsAccount implements IWindowsAccount {
         return this.fqn;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAccount#getName()
      */
     @Override
@@ -94,7 +100,9 @@ public class MockWindowsAccount implements IWindowsAccount {
         return this.name;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAccount#getSidString()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
@@ -60,7 +60,6 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#acceptSecurityToken(java.lang.String, byte[], java.lang.String)
      */
     @Override
@@ -71,7 +70,6 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#getCurrentComputer()
      */
     @Override
@@ -81,7 +79,6 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#getDomains()
      */
     @Override
@@ -91,7 +88,6 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUser(java.lang.String, java.lang.String,
      * java.lang.String)
      */
@@ -102,7 +98,6 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUserEx(java.lang.String, java.lang.String,
      * java.lang.String, int, int)
      */
@@ -135,7 +130,6 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#lookupAccount(java.lang.String)
      */
     @Override
@@ -145,7 +139,6 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#resetSecurityToken(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
@@ -38,7 +38,7 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
     private static final String GUEST  = "Guest";
 
     /** The groups. */
-    private final List<String>        groups = new ArrayList<>();
+    private final List<String>  groups = new ArrayList<>();
 
     /**
      * Instantiates a new mock windows auth provider.
@@ -58,7 +58,9 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
         this.groups.add(name);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#acceptSecurityToken(java.lang.String, byte[], java.lang.String)
      */
     @Override
@@ -67,7 +69,9 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
         return new MockWindowsSecurityContext(new String(token, Charsets.UTF_8));
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#getCurrentComputer()
      */
     @Override
@@ -75,7 +79,9 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#getDomains()
      */
     @Override
@@ -83,16 +89,22 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
         return new IWindowsDomain[0];
     }
 
-    /* (non-Javadoc)
-     * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUser(java.lang.String, java.lang.String, java.lang.String)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUser(java.lang.String, java.lang.String,
+     * java.lang.String)
      */
     @Override
     public IWindowsIdentity logonDomainUser(final String username, final String domain, final String password) {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUserEx(java.lang.String, java.lang.String, java.lang.String, int, int)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.windows.auth.IWindowsAuthProvider#logonDomainUserEx(java.lang.String, java.lang.String,
+     * java.lang.String, int, int)
      */
     @Override
     public IWindowsIdentity logonDomainUserEx(final String username, final String domain, final String password,
@@ -121,7 +133,9 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#lookupAccount(java.lang.String)
      */
     @Override
@@ -129,7 +143,9 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsAuthProvider#resetSecurityToken(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
@@ -29,7 +29,7 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     /** The fqn. */
     private final String       fqn;
-    
+
     /** The groups. */
     private final List<String> groups;
 
@@ -46,7 +46,9 @@ public class MockWindowsIdentity implements IWindowsIdentity {
         this.groups = newGroups;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#getFqn()
      */
     @Override
@@ -54,7 +56,9 @@ public class MockWindowsIdentity implements IWindowsIdentity {
         return this.fqn;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#getGroups()
      */
     @Override
@@ -66,7 +70,9 @@ public class MockWindowsIdentity implements IWindowsIdentity {
         return groupsList.toArray(new IWindowsAccount[0]);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#getSid()
      */
     @Override
@@ -74,7 +80,9 @@ public class MockWindowsIdentity implements IWindowsIdentity {
         return new byte[0];
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#getSidString()
      */
     @Override
@@ -82,7 +90,9 @@ public class MockWindowsIdentity implements IWindowsIdentity {
         return "S-" + this.fqn.hashCode();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#dispose()
      */
     @Override
@@ -90,7 +100,9 @@ public class MockWindowsIdentity implements IWindowsIdentity {
         // Do Nothing
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#isGuest()
      */
     @Override
@@ -98,7 +110,9 @@ public class MockWindowsIdentity implements IWindowsIdentity {
         return this.fqn.equals("Guest");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsIdentity#impersonate()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
@@ -48,7 +48,6 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#getFqn()
      */
     @Override
@@ -58,7 +57,6 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#getGroups()
      */
     @Override
@@ -72,7 +70,6 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#getSid()
      */
     @Override
@@ -82,7 +79,6 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#getSidString()
      */
     @Override
@@ -92,7 +88,6 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#dispose()
      */
     @Override
@@ -102,7 +97,6 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#isGuest()
      */
     @Override
@@ -112,7 +106,6 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsIdentity#impersonate()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
@@ -24,7 +24,6 @@ public class MockWindowsImpersonationContext implements IWindowsImpersonationCon
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsImpersonationContext#revertToSelf()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
@@ -22,7 +22,9 @@ import waffle.windows.auth.IWindowsImpersonationContext;
  */
 public class MockWindowsImpersonationContext implements IWindowsImpersonationContext {
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsImpersonationContext#revertToSelf()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
@@ -46,7 +46,9 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
         this.identity = new MockWindowsIdentity(username, groups);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#dispose()
      */
     @Override
@@ -54,7 +56,9 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
         // Do Nothing
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#isContinue()
      */
     @Override
@@ -62,7 +66,9 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
         return false;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getHandle()
      */
     @Override
@@ -70,7 +76,9 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
         return new CtxtHandle();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getIdentity()
      */
     @Override
@@ -78,7 +86,9 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
         return this.identity;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getPrincipalName()
      */
     @Override
@@ -86,7 +96,9 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
         return this.identity.getFqn();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getSecurityPackage()
      */
     @Override
@@ -94,7 +106,9 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
         return "Mock";
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getToken()
      */
     @Override
@@ -102,7 +116,9 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
         return new byte[0];
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#impersonate()
      */
     @Override
@@ -117,8 +133,11 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
         // Do Nothing
     }
 
-    /* (non-Javadoc)
-     * @see waffle.windows.auth.IWindowsSecurityContext#initialize(com.sun.jna.platform.win32.Sspi.CtxtHandle, com.sun.jna.platform.win32.Sspi.SecBufferDesc, java.lang.String)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see waffle.windows.auth.IWindowsSecurityContext#initialize(com.sun.jna.platform.win32.Sspi.CtxtHandle,
+     * com.sun.jna.platform.win32.Sspi.SecBufferDesc, java.lang.String)
      */
     @Override
     public void initialize(final CtxtHandle continueCtx, final SecBufferDesc continueToken,

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
@@ -48,7 +48,6 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#dispose()
      */
     @Override
@@ -58,7 +57,6 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#isContinue()
      */
     @Override
@@ -68,7 +66,6 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getHandle()
      */
     @Override
@@ -78,7 +75,6 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getIdentity()
      */
     @Override
@@ -88,7 +84,6 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getPrincipalName()
      */
     @Override
@@ -98,7 +93,6 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getSecurityPackage()
      */
     @Override
@@ -108,7 +102,6 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#getToken()
      */
     @Override
@@ -118,7 +111,6 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#impersonate()
      */
     @Override
@@ -135,7 +127,6 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     /*
      * (non-Javadoc)
-     * 
      * @see waffle.windows.auth.IWindowsSecurityContext#initialize(com.sun.jna.platform.win32.Sspi.CtxtHandle,
      * com.sun.jna.platform.win32.Sspi.SecBufferDesc, java.lang.String)
      */

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
@@ -53,7 +53,6 @@ public class SimpleFilterChain implements FilterChain {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.FilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
@@ -29,7 +29,7 @@ public class SimpleFilterChain implements FilterChain {
 
     /** The request. */
     private ServletRequest  request;
-    
+
     /** The response. */
     private ServletResponse response;
 
@@ -51,7 +51,9 @@ public class SimpleFilterChain implements FilterChain {
         return this.response;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.FilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
@@ -38,7 +38,6 @@ public class SimpleFilterConfig implements FilterConfig {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.FilterConfig#getFilterName()
      */
     @Override
@@ -58,7 +57,6 @@ public class SimpleFilterConfig implements FilterConfig {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.FilterConfig#getInitParameter(java.lang.String)
      */
     @Override
@@ -68,7 +66,6 @@ public class SimpleFilterConfig implements FilterConfig {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.FilterConfig#getInitParameterNames()
      */
     @Override
@@ -80,7 +77,6 @@ public class SimpleFilterConfig implements FilterConfig {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.FilterConfig#getServletContext()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
@@ -31,12 +31,14 @@ import javax.servlet.ServletContext;
 public class SimpleFilterConfig implements FilterConfig {
 
     /** The filter name. */
-    private String              filterName = "Simple Filter";
-    
+    private String                    filterName = "Simple Filter";
+
     /** The parameters. */
     private final Map<String, String> parameters = new TreeMap<>();
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.FilterConfig#getFilterName()
      */
     @Override
@@ -54,7 +56,9 @@ public class SimpleFilterConfig implements FilterConfig {
         this.filterName = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.FilterConfig#getInitParameter(java.lang.String)
      */
     @Override
@@ -62,7 +66,9 @@ public class SimpleFilterConfig implements FilterConfig {
         return this.parameters.get(s);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.FilterConfig#getInitParameterNames()
      */
     @Override
@@ -72,7 +78,9 @@ public class SimpleFilterConfig implements FilterConfig {
         return Collections.enumeration(keys);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.FilterConfig#getServletContext()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
@@ -110,7 +110,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getHeader(java.lang.String)
      */
     @Override
@@ -120,7 +119,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getHeaderNames()
      */
     @Override
@@ -130,7 +128,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getMethod()
      */
     @Override
@@ -140,7 +137,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.ServletRequestWrapper#getContentLength()
      */
     @Override
@@ -150,7 +146,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.ServletRequestWrapper#getRemotePort()
      */
     @Override
@@ -190,7 +185,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getRemoteUser()
      */
     @Override
@@ -200,7 +194,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getSession()
      */
     @Override
@@ -210,7 +203,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getSession(boolean)
      */
     @Override
@@ -223,7 +215,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getQueryString()
      */
     @Override
@@ -260,7 +251,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getRequestURI()
      */
     @Override
@@ -270,7 +260,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.ServletRequestWrapper#getParameter(java.lang.String)
      */
     @Override
@@ -292,7 +281,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.ServletRequestWrapper#getRemoteHost()
      */
     @Override
@@ -312,7 +300,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.ServletRequestWrapper#getRemoteAddr()
      */
     @Override
@@ -332,7 +319,6 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getUserPrincipal()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
@@ -34,43 +34,43 @@ import com.google.common.collect.Iterators;
 public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
     /** The remote port s. */
-    private static int          remotePortS = 0;
+    private static int                remotePortS = 0;
 
     /** The request uri. */
-    private String              requestURI;
-    
+    private String                    requestURI;
+
     /** The query string. */
-    private String              queryString;
-    
+    private String                    queryString;
+
     /** The remote user. */
-    private String              remoteUser;
-    
+    private String                    remoteUser;
+
     /** The method. */
-    private String              method      = "GET";
-    
+    private String                    method      = "GET";
+
     /** The remote host. */
-    private String              remoteHost;
-    
+    private String                    remoteHost;
+
     /** The remote addr. */
-    private String              remoteAddr;
-    
+    private String                    remoteAddr;
+
     /** The remote port. */
-    private int                 remotePort  = -1;
-    
+    private int                       remotePort  = -1;
+
     /** The headers. */
     private final Map<String, String> headers     = new HashMap<>();
-    
+
     /** The parameters. */
     private final Map<String, String> parameters  = new HashMap<>();
-    
+
     /** The content. */
-    private byte[]              content;
-    
+    private byte[]                    content;
+
     /** The session. */
-    private HttpSession         session     = new SimpleHttpSession();
-    
+    private HttpSession               session     = new SimpleHttpSession();
+
     /** The principal. */
-    private Principal           principal;
+    private Principal                 principal;
 
     /**
      * Instantiates a new simple http request.
@@ -108,7 +108,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         this.headers.put(headerName, headerValue);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getHeader(java.lang.String)
      */
     @Override
@@ -116,7 +118,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         return this.headers.get(headerName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getHeaderNames()
      */
     @Override
@@ -124,7 +128,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         return Iterators.asEnumeration(this.headers.keySet().iterator());
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getMethod()
      */
     @Override
@@ -132,7 +138,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         return this.method;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.ServletRequestWrapper#getContentLength()
      */
     @Override
@@ -140,7 +148,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         return this.content == null ? -1 : this.content.length;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.ServletRequestWrapper#getRemotePort()
      */
     @Override
@@ -178,7 +188,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         this.remoteUser = username;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getRemoteUser()
      */
     @Override
@@ -186,7 +198,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         return this.remoteUser;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getSession()
      */
     @Override
@@ -194,7 +208,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         return this.session;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getSession(boolean)
      */
     @Override
@@ -205,7 +221,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         return this.session;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getQueryString()
      */
     @Override
@@ -240,7 +258,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         this.requestURI = uri;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getRequestURI()
      */
     @Override
@@ -248,7 +268,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         return this.requestURI;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.ServletRequestWrapper#getParameter(java.lang.String)
      */
     @Override
@@ -268,7 +290,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         this.parameters.put(parameterName, parameterValue);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.ServletRequestWrapper#getRemoteHost()
      */
     @Override
@@ -286,7 +310,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         this.remoteHost = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.ServletRequestWrapper#getRemoteAddr()
      */
     @Override
@@ -304,7 +330,9 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         this.remoteAddr = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletRequestWrapper#getUserPrincipal()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
@@ -80,7 +80,6 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -95,7 +94,6 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#setHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -112,7 +110,6 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#setStatus(int)
      */
     @Override
@@ -134,7 +131,6 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.ServletResponseWrapper#flushBuffer()
      */
     @Override
@@ -182,7 +178,6 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#sendError(int, java.lang.String)
      */
     @Override
@@ -192,7 +187,6 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#sendError(int)
      */
     @Override
@@ -202,7 +196,6 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.ServletResponseWrapper#getWriter()
      */
     @Override
@@ -212,7 +205,6 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.ServletResponseWrapper#getOutputStream()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
@@ -40,27 +40,27 @@ import com.google.common.base.Joiner;
 public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     /** The Constant LOGGER. */
-    private static final Logger       LOGGER  = LoggerFactory.getLogger(SimpleHttpResponse.class);
+    private static final Logger             LOGGER  = LoggerFactory.getLogger(SimpleHttpResponse.class);
 
     /** The status. */
-    private int                       status  = 500;
-    
+    private int                             status  = 500;
+
     /** The headers. */
     private final Map<String, List<String>> headers = new HashMap<>();
 
     /** The bytes. */
-    final ByteArrayOutputStream       bytes   = new ByteArrayOutputStream();
+    final ByteArrayOutputStream             bytes   = new ByteArrayOutputStream();
 
     /** The out. */
-    private final ServletOutputStream out     = new ServletOutputStream() {
-                                                  @Override
-                                                  public void write(final int b) throws IOException {
-                                                      SimpleHttpResponse.this.bytes.write(b);
-                                                  }
-                                              };
+    private final ServletOutputStream       out     = new ServletOutputStream() {
+                                                        @Override
+                                                        public void write(final int b) throws IOException {
+                                                            SimpleHttpResponse.this.bytes.write(b);
+                                                        }
+                                                    };
 
     /** The writer. */
-    private final PrintWriter         writer  = new PrintWriter(this.bytes);
+    private final PrintWriter               writer  = new PrintWriter(this.bytes);
 
     /**
      * Instantiates a new simple http response.
@@ -78,7 +78,9 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
         return this.status;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -91,7 +93,9 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
         this.headers.put(headerName, current);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#setHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -106,7 +110,9 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
         this.headers.put(headerName, current);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#setStatus(int)
      */
     @Override
@@ -126,7 +132,9 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
         return "Unknown";
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.ServletResponseWrapper#flushBuffer()
      */
     @Override
@@ -172,7 +180,9 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
         return headerValues == null ? null : Joiner.on(", ").join(headerValues);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#sendError(int, java.lang.String)
      */
     @Override
@@ -180,7 +190,9 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
         this.status = rc;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpServletResponseWrapper#sendError(int)
      */
     @Override
@@ -188,7 +200,9 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
         this.status = rc;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.ServletResponseWrapper#getWriter()
      */
     @Override
@@ -196,7 +210,9 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
         return this.writer;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.ServletResponseWrapper#getOutputStream()
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
@@ -34,7 +34,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getAttribute(java.lang.String)
      */
     @Override
@@ -44,7 +43,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getAttributeNames()
      */
     @Override
@@ -54,7 +52,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getCreationTime()
      */
     @Override
@@ -64,7 +61,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getId()
      */
     @Override
@@ -74,7 +70,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getLastAccessedTime()
      */
     @Override
@@ -84,7 +79,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getMaxInactiveInterval()
      */
     @Override
@@ -94,7 +88,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getServletContext()
      */
     @Override
@@ -104,7 +97,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getSessionContext()
      */
     @Deprecated
@@ -115,7 +107,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getValue(java.lang.String)
      */
     @Deprecated
@@ -126,7 +117,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getValueNames()
      */
     @Deprecated
@@ -137,7 +127,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#invalidate()
      */
     @Override
@@ -147,7 +136,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#isNew()
      */
     @Override
@@ -157,7 +145,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#putValue(java.lang.String, java.lang.Object)
      */
     @Deprecated
@@ -168,7 +155,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#removeAttribute(java.lang.String)
      */
     @Override
@@ -178,7 +164,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#removeValue(java.lang.String)
      */
     @Deprecated
@@ -189,7 +174,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#setAttribute(java.lang.String, java.lang.Object)
      */
     @Override
@@ -199,7 +183,6 @@ public class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#setMaxInactiveInterval(int)
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
@@ -32,7 +32,9 @@ public class SimpleHttpSession implements HttpSession {
     /** The attributes. */
     private final Map<String, Object> attributes = new HashMap<>();
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getAttribute(java.lang.String)
      */
     @Override
@@ -40,7 +42,9 @@ public class SimpleHttpSession implements HttpSession {
         return this.attributes.get(attributeName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getAttributeNames()
      */
     @Override
@@ -48,7 +52,9 @@ public class SimpleHttpSession implements HttpSession {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getCreationTime()
      */
     @Override
@@ -56,7 +62,9 @@ public class SimpleHttpSession implements HttpSession {
         return 0;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getId()
      */
     @Override
@@ -64,7 +72,9 @@ public class SimpleHttpSession implements HttpSession {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getLastAccessedTime()
      */
     @Override
@@ -72,7 +82,9 @@ public class SimpleHttpSession implements HttpSession {
         return 0;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getMaxInactiveInterval()
      */
     @Override
@@ -80,7 +92,9 @@ public class SimpleHttpSession implements HttpSession {
         return 0;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getServletContext()
      */
     @Override
@@ -88,7 +102,9 @@ public class SimpleHttpSession implements HttpSession {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getSessionContext()
      */
     @Deprecated
@@ -97,7 +113,9 @@ public class SimpleHttpSession implements HttpSession {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getValue(java.lang.String)
      */
     @Deprecated
@@ -106,7 +124,9 @@ public class SimpleHttpSession implements HttpSession {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getValueNames()
      */
     @Deprecated
@@ -115,7 +135,9 @@ public class SimpleHttpSession implements HttpSession {
         return new String[0];
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#invalidate()
      */
     @Override
@@ -123,7 +145,9 @@ public class SimpleHttpSession implements HttpSession {
         // Do Nothing
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#isNew()
      */
     @Override
@@ -131,7 +155,9 @@ public class SimpleHttpSession implements HttpSession {
         return false;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#putValue(java.lang.String, java.lang.Object)
      */
     @Deprecated
@@ -140,7 +166,9 @@ public class SimpleHttpSession implements HttpSession {
         // Do Nothing
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#removeAttribute(java.lang.String)
      */
     @Override
@@ -148,7 +176,9 @@ public class SimpleHttpSession implements HttpSession {
         this.attributes.remove(attributeName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#removeValue(java.lang.String)
      */
     @Deprecated
@@ -157,7 +187,9 @@ public class SimpleHttpSession implements HttpSession {
         // Do Nothing
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#setAttribute(java.lang.String, java.lang.Object)
      */
     @Override
@@ -165,7 +197,9 @@ public class SimpleHttpSession implements HttpSession {
         this.attributes.put(attributeName, attributeValue);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#setMaxInactiveInterval(int)
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
@@ -41,7 +41,9 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
         this.url = newUrl;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.RequestDispatcher#forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override
@@ -52,7 +54,9 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
         httpResponse.addHeader("Location", this.url);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.RequestDispatcher#include(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
@@ -43,7 +43,6 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.RequestDispatcher#forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override
@@ -56,7 +55,6 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.RequestDispatcher#include(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
@@ -27,25 +27,29 @@ import javax.security.auth.callback.UnsupportedCallbackException;
  * @author dblock[at]dblock[dot]org
  */
 public class UsernamePasswordCallbackHandler implements CallbackHandler {
-    
+
     /** The username. */
     private final String username;
-    
+
     /** The password. */
     private final String password;
 
     /**
      * Instantiates a new username password callback handler.
      *
-     * @param newUsername the new username
-     * @param newPassword the new password
+     * @param newUsername
+     *            the new username
+     * @param newPassword
+     *            the new password
      */
     public UsernamePasswordCallbackHandler(final String newUsername, final String newPassword) {
         this.username = newUsername;
         this.password = newPassword;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.security.auth.callback.CallbackHandler#handle(javax.security.auth.callback.Callback[])
      */
     @Override

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
@@ -49,7 +49,6 @@ public class UsernamePasswordCallbackHandler implements CallbackHandler {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.security.auth.callback.CallbackHandler#handle(javax.security.auth.callback.Callback[])
      */
     @Override

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
@@ -35,10 +35,10 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
  * @author dblock[at]dblock[dot]org
  */
 public class WindowsLoginModuleTests {
-    
+
     /** The login module. */
     WindowsLoginModule      loginModule;
-    
+
     /** The provider. */
     MockWindowsAuthProvider provider;
 
@@ -78,7 +78,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test login.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void testLogin() throws LoginException {
@@ -102,7 +103,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test no callback handler.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test(expected = LoginException.class)
     public void testNoCallbackHandler() throws LoginException {
@@ -115,7 +117,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test login no username.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test(expected = LoginException.class)
     public void testLoginNoUsername() throws LoginException {
@@ -131,7 +134,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test role format none.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void testRoleFormatNone() throws LoginException {
@@ -150,7 +154,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test role format both.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void testRoleFormatBoth() throws LoginException {
@@ -169,7 +174,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test principal format both.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void testPrincipalFormatBoth() throws LoginException {
@@ -189,7 +195,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test role format sid.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void testRoleFormatSid() throws LoginException {
@@ -212,7 +219,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test role unique.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void testRoleUnique() throws LoginException {
@@ -233,7 +241,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test guest login.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test(expected = LoginException.class)
     public void testGuestLogin() throws LoginException {
@@ -257,7 +266,8 @@ public class WindowsLoginModuleTests {
     /**
      * Test abort.
      *
-     * @throws LoginException the login exception
+     * @throws LoginException
+     *             the login exception
      */
     @Test
     public void testAbort() throws LoginException {

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/BasicSecurityFilterTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/BasicSecurityFilterTests.java
@@ -46,7 +46,8 @@ public class BasicSecurityFilterTests {
     /**
      * Sets the up.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Before
     public void setUp() throws ServletException {
@@ -66,8 +67,10 @@ public class BasicSecurityFilterTests {
     /**
      * Test basic auth.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testBasicAuth() throws IOException, ServletException {

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/ImpersonateTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/ImpersonateTests.java
@@ -48,10 +48,10 @@ public class ImpersonateTests {
 
     /** The filter. */
     private NegotiateSecurityFilter filter;
-    
+
     /** The user info. */
     private LMAccess.USER_INFO_1    userInfo;
-    
+
     /** The result of net add user. */
     private int                     resultOfNetAddUser;
 
@@ -86,21 +86,24 @@ public class ImpersonateTests {
         this.filter.destroy();
 
         if (LMErr.NERR_Success == this.resultOfNetAddUser) {
-            Assert.assertEquals(LMErr.NERR_Success, Netapi32.INSTANCE.NetUserDel(null, this.userInfo.usri1_name.toString()));
+            Assert.assertEquals(LMErr.NERR_Success,
+                    Netapi32.INSTANCE.NetUserDel(null, this.userInfo.usri1_name.toString()));
         }
     }
 
     /**
      * Test impersonate enabled.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testImpersonateEnabled() throws IOException, ServletException {
 
-        Assert.assertFalse("Current user shouldn't be the test user prior to the test",
-                Advapi32Util.getUserName().equals(MockWindowsAccount.TEST_USER_NAME));
+        Assert.assertFalse("Current user shouldn't be the test user prior to the test", Advapi32Util.getUserName()
+                .equals(MockWindowsAccount.TEST_USER_NAME));
 
         final SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
@@ -142,14 +145,16 @@ public class ImpersonateTests {
     /**
      * Test impersonate disabled.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testImpersonateDisabled() throws IOException, ServletException {
 
-        Assert.assertFalse("Current user shouldn't be the test user prior to the test",
-                Advapi32Util.getUserName().equals(MockWindowsAccount.TEST_USER_NAME));
+        Assert.assertFalse("Current user shouldn't be the test user prior to the test", Advapi32Util.getUserName()
+                .equals(MockWindowsAccount.TEST_USER_NAME));
         final SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         final String userHeaderValue = MockWindowsAccount.TEST_USER_NAME + ":" + MockWindowsAccount.TEST_PASSWORD;
@@ -190,15 +195,18 @@ public class ImpersonateTests {
      * Filter chain that records current username.
      */
     public static class RecordUserNameFilterChain extends SimpleFilterChain {
-        
+
         /** The user name. */
         private String userName;
 
-        /* (non-Javadoc)
+        /*
+         * (non-Javadoc)
+         * 
          * @see waffle.mock.http.SimpleFilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
          */
         @Override
-        public void doFilter(final ServletRequest sreq, final ServletResponse srep) throws IOException, ServletException {
+        public void doFilter(final ServletRequest sreq, final ServletResponse srep) throws IOException,
+                ServletException {
             this.userName = Advapi32Util.getUserName();
         }
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/ImpersonateTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/ImpersonateTests.java
@@ -201,7 +201,6 @@ public class ImpersonateTests {
 
         /*
          * (non-Javadoc)
-         * 
          * @see waffle.mock.http.SimpleFilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
          */
         @Override

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTests.java
@@ -31,7 +31,7 @@ public class NegotiateSecurityFilterLoadTests {
 
     /** The conti perf rule. */
     @Rule
-    public ContiPerfRule                 contiPerfRule = new ContiPerfRule();
+    public ContiPerfRule                       contiPerfRule = new ContiPerfRule();
 
     /** The tests. */
     private final NegotiateSecurityFilterTests tests         = new NegotiateSecurityFilterTests();
@@ -39,7 +39,8 @@ public class NegotiateSecurityFilterLoadTests {
     /**
      * Sets the up.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Before
     public void setUp() throws ServletException {
@@ -57,7 +58,8 @@ public class NegotiateSecurityFilterLoadTests {
     /**
      * Test load.
      *
-     * @throws Throwable the throwable
+     * @throws Throwable
+     *             the throwable
      */
     @Test
     @PerfTest(invocations = 10, threads = 10)

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTests.java
@@ -54,7 +54,7 @@ public class NegotiateSecurityFilterTests {
 
     /** The Constant NEGOTIATE. */
     private static final String     NEGOTIATE = "Negotiate";
-    
+
     /** The Constant NTLM. */
     private static final String     NTLM      = "NTLM";
 
@@ -64,7 +64,8 @@ public class NegotiateSecurityFilterTests {
     /**
      * Sets the up.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Before
     public void setUp() throws ServletException {
@@ -84,8 +85,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test challenge get.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testChallengeGET() throws IOException, ServletException {
@@ -106,8 +109,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test challenge post.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testChallengePOST() throws IOException, ServletException {
@@ -148,8 +153,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test negotiate.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testNegotiate() throws IOException, ServletException {
@@ -193,7 +200,8 @@ public class NegotiateSecurityFilterTests {
                 Assert.assertEquals("keep-alive", response.getHeader("Connection"));
                 Assert.assertEquals(2, response.getHeaderNamesSize());
                 Assert.assertEquals(401, response.getStatus());
-                final String continueToken = response.getHeader("WWW-Authenticate").substring(securityPackage.length() + 1);
+                final String continueToken = response.getHeader("WWW-Authenticate").substring(
+                        securityPackage.length() + 1);
                 final byte[] continueTokenBytes = BaseEncoding.base64().decode(continueToken);
                 Assertions.assertThat(continueTokenBytes.length).isGreaterThan(0);
                 final SecBufferDesc continueTokenBuffer = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, continueTokenBytes);
@@ -223,8 +231,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test negotiate previous auth with windows principal.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testNegotiatePreviousAuthWithWindowsPrincipal() throws IOException, ServletException {
@@ -244,8 +254,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test challenge ntlmpost.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testChallengeNTLMPOST() throws IOException, ServletException {
@@ -271,8 +283,10 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test challenge ntlmput.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ServletException the servlet exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testChallengeNTLMPUT() throws IOException, ServletException {
@@ -298,7 +312,8 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test init basic security filter provider.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testInitBasicSecurityFilterProvider() throws ServletException {
@@ -320,7 +335,8 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test init two security filter providers.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testInitTwoSecurityFilterProviders() throws ServletException {
@@ -335,7 +351,8 @@ public class NegotiateSecurityFilterTests {
     /**
      * Test init negotiate security filter provider.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testInitNegotiateSecurityFilterProvider() throws ServletException {

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WaffleInfoServletTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WaffleInfoServletTests.java
@@ -45,7 +45,8 @@ public class WaffleInfoServletTests {
     /**
      * Test get info.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void testGetInfo() throws Exception {
@@ -63,8 +64,8 @@ public class WaffleInfoServletTests {
         WaffleInfoServletTests.LOGGER.info("GOT: {}", xml);
 
         // Make sure JNA Version is properly noted
-        Assert.assertEquals(Platform.class.getPackage().getImplementationVersion(),
-                doc.getDocumentElement().getAttribute("jna"));
+        Assert.assertEquals(Platform.class.getPackage().getImplementationVersion(), doc.getDocumentElement()
+                .getAttribute("jna"));
 
         final Node node = doc.getDocumentElement().getFirstChild().getNextSibling() // request
                 .getFirstChild().getNextSibling() // AuthType
@@ -79,11 +80,15 @@ public class WaffleInfoServletTests {
     /**
      * Load xml from string.
      *
-     * @param xml the xml
+     * @param xml
+     *            the xml
      * @return the document
-     * @throws ParserConfigurationException the parser configuration exception
-     * @throws SAXException the SAX exception
-     * @throws IOException Signals that an I/O exception has occurred.
+     * @throws ParserConfigurationException
+     *             the parser configuration exception
+     * @throws SAXException
+     *             the SAX exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
      */
     private static Document loadXMLFromString(final String xml) throws ParserConfigurationException, SAXException,
             IOException {

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WindowsPrincipalTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WindowsPrincipalTests.java
@@ -50,8 +50,10 @@ public class WindowsPrincipalTests {
     /**
      * Test is serializable.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ClassNotFoundException the class not found exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test
     public void testIsSerializable() throws IOException, ClassNotFoundException {

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTests.java
@@ -28,7 +28,7 @@ public class WindowsAuthProviderLoadTests {
 
     /** The conti perf rule. */
     @Rule
-    public ContiPerfRule             contiPerfRule = new ContiPerfRule();
+    public ContiPerfRule                   contiPerfRule = new ContiPerfRule();
 
     /** The tests. */
     private final WindowsAuthProviderTests tests         = new WindowsAuthProviderTests();
@@ -36,7 +36,8 @@ public class WindowsAuthProviderLoadTests {
     /**
      * Test load.
      *
-     * @throws Throwable the throwable
+     * @throws Throwable
+     *             the throwable
      */
     @Test
     @PerfTest(invocations = 10, threads = 10)

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
@@ -183,9 +183,11 @@ public class WindowsAuthProviderTests {
 
                 if (serverContext != null && serverContext.isContinue()) {
                     // initialize on the client
-                    final SecBufferDesc continueToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, serverContext.getToken());
+                    final SecBufferDesc continueToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN,
+                            serverContext.getToken());
                     clientContext.initialize(clientContext.getHandle(), continueToken, targetName);
-                    WindowsAuthProviderTests.LOGGER.debug("Token: {}", BaseEncoding.base64().encode(serverContext.getToken()));
+                    WindowsAuthProviderTests.LOGGER.debug("Token: {}",
+                            BaseEncoding.base64().encode(serverContext.getToken()));
                 }
 
             } while (clientContext.isContinue() || serverContext != null && serverContext.isContinue());
@@ -214,7 +216,8 @@ public class WindowsAuthProviderTests {
     /**
      * Test security contexts expire.
      *
-     * @throws InterruptedException the interrupted exception
+     * @throws InterruptedException
+     *             the interrupted exception
      */
     @Test
     public void testSecurityContextsExpire() throws InterruptedException {
@@ -241,7 +244,8 @@ public class WindowsAuthProviderTests {
                 serverContext = provider.acceptSecurityToken(connectionId, clientContext.getToken(), securityPackage);
                 Assertions.assertThat(provider.getContinueContextsSize()).isGreaterThan(0);
             }
-            WindowsAuthProviderTests.LOGGER.debug("Cached security contexts: {}", Integer.valueOf(provider.getContinueContextsSize()));
+            WindowsAuthProviderTests.LOGGER.debug("Cached security contexts: {}",
+                    Integer.valueOf(provider.getContinueContextsSize()));
             Assert.assertFalse(max == provider.getContinueContextsSize());
         } finally {
             if (serverContext != null) {
@@ -291,7 +295,8 @@ public class WindowsAuthProviderTests {
 
                 if (serverContext != null && serverContext.isContinue()) {
                     // initialize on the client
-                    final SecBufferDesc continueToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, serverContext.getToken());
+                    final SecBufferDesc continueToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN,
+                            serverContext.getToken());
                     clientContext.initialize(clientContext.getHandle(), continueToken, targetName);
                 }
 

--- a/Source/JNA/waffle-tomcat6/format.xml
+++ b/Source/JNA/waffle-tomcat6/format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/Source/JNA/waffle-tomcat6/pom.xml
+++ b/Source/JNA/waffle-tomcat6/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <tomcat.version>6.0.44</tomcat.version>
     </properties>

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -37,10 +37,10 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
 
     /** The sid. */
     private final byte[]                      sid;
-    
+
     /** The sid string. */
     private final String                      sidString;
-    
+
     /** The groups. */
     private final Map<String, WindowsAccount> groups;
 
@@ -58,8 +58,8 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      */
     public GenericWindowsPrincipal(final IWindowsIdentity newWindowsIdentity, final Realm newRealm,
             final PrincipalFormat newPrincipalFormat, final PrincipalFormat newRoleFormat) {
-        super(newRealm, newWindowsIdentity.getFqn(), "",
-                GenericWindowsPrincipal.getRoles(newWindowsIdentity, newPrincipalFormat, newRoleFormat));
+        super(newRealm, newWindowsIdentity.getFqn(), "", GenericWindowsPrincipal.getRoles(newWindowsIdentity,
+                newPrincipalFormat, newRoleFormat));
         this.sid = newWindowsIdentity.getSid();
         this.sidString = newWindowsIdentity.getSidString();
         this.groups = GenericWindowsPrincipal.getGroups(newWindowsIdentity.getGroups());

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -51,7 +51,9 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         this.log.debug("[waffle.apache.MixedAuthenticator] loaded");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#start()
      */
     @Override
@@ -59,7 +61,9 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         this.log.info("[waffle.apache.MixedAuthenticator] started");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stop()
      */
     @Override
@@ -67,8 +71,11 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         this.log.info("[waffle.apache.MixedAuthenticator] stopped");
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request, org.apache.catalina.connector.Response, org.apache.catalina.deploy.LoginConfig)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
+     * org.apache.catalina.connector.Response, org.apache.catalina.deploy.LoginConfig)
      */
     @Override
     public boolean authenticate(final Request request, final Response response, final LoginConfig loginConfig) {

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -53,7 +53,6 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#start()
      */
     @Override
@@ -63,7 +62,6 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stop()
      */
     @Override
@@ -73,7 +71,6 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
      * org.apache.catalina.connector.Response, org.apache.catalina.deploy.LoginConfig)
      */

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -49,7 +49,9 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#start()
      */
     @Override
@@ -57,7 +59,9 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.log.info("[waffle.apache.NegotiateAuthenticator] started");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stop()
      */
     @Override
@@ -65,8 +69,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.log.info("[waffle.apache.NegotiateAuthenticator] stopped");
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request, org.apache.catalina.connector.Response, org.apache.catalina.deploy.LoginConfig)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
+     * org.apache.catalina.connector.Response, org.apache.catalina.deploy.LoginConfig)
      */
     @Override
     public boolean authenticate(final Request request, final Response response, final LoginConfig loginConfig) {

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -51,7 +51,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#start()
      */
     @Override
@@ -61,7 +60,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stop()
      */
     @Override
@@ -71,7 +69,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
      * org.apache.catalina.connector.Response, org.apache.catalina.deploy.LoginConfig)
      */

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -81,7 +81,6 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#getInfo()
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -41,19 +41,19 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /** The info. */
     protected String                 info;
-    
+
     /** The log. */
     protected Logger                 log;
-    
+
     /** The principal format. */
     protected PrincipalFormat        principalFormat     = PrincipalFormat.FQN;
-    
+
     /** The role format. */
     protected PrincipalFormat        roleFormat          = PrincipalFormat.FQN;
-    
+
     /** The allow guest login. */
     protected boolean                allowGuestLogin     = true;
-    
+
     /** The protocols. */
     protected Set<String>            protocols           = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
 
@@ -79,7 +79,9 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         this.auth = provider;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#getInfo()
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WindowsRealm.java
@@ -29,7 +29,6 @@ public class WindowsRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override
@@ -39,7 +38,6 @@ public class WindowsRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getPassword(java.lang.String)
      */
     @Override
@@ -49,7 +47,6 @@ public class WindowsRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getPrincipal(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WindowsRealm.java
@@ -27,7 +27,9 @@ public class WindowsRealm extends RealmBase {
     /** The Constant NAME. */
     protected static final String NAME = "waffle.apache.WindowsRealm/1.0";
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override
@@ -35,7 +37,9 @@ public class WindowsRealm extends RealmBase {
         return WindowsRealm.NAME;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getPassword(java.lang.String)
      */
     @Override
@@ -43,7 +47,9 @@ public class WindowsRealm extends RealmBase {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getPrincipal(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -54,7 +54,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_accept_both_protocols.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void should_accept_both_protocols() throws Exception {
@@ -68,7 +69,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_accept_ negotiate_protocol.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void should_accept_Negotiate_protocol() throws Exception {
@@ -81,7 +83,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_accept_ ntl m_protocol.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void should_accept_NTLM_protocol() throws Exception {
@@ -94,7 +97,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_refuse_other_protocol.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test(expected = RuntimeException.class)
     public void should_refuse_other_protocol() throws Exception {

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -37,7 +37,7 @@ public class WindowsAccountTests {
 
     /** The mock windows account. */
     private final MockWindowsAccount mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
-    
+
     /** The windows account. */
     private WindowsAccount           windowsAccount;
 
@@ -62,8 +62,10 @@ public class WindowsAccountTests {
     /**
      * Test is serializable.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ClassNotFoundException the class not found exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test
     public void testIsSerializable() throws IOException, ClassNotFoundException {

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -27,7 +27,7 @@ public abstract class SimpleContext implements Context {
 
     /** The realm. */
     private Realm          realm;
-    
+
     /** The servlet context. */
     private ServletContext servletContext;
 
@@ -51,7 +51,9 @@ public abstract class SimpleContext implements Context {
         return this.servletContext;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.Container#setRealm(org.apache.catalina.Realm)
      */
     @Override
@@ -62,7 +64,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Servlet Context Used By Waffle.
      *
-     * @param value the new servlet context
+     * @param value
+     *            the new servlet context
      */
     public void setServletContext(final ServletContext value) {
         this.servletContext = value;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -53,7 +53,6 @@ public abstract class SimpleContext implements Context {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.Container#setRealm(org.apache.catalina.Realm)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -29,11 +29,13 @@ public class SimpleFilterChain implements FilterChain {
 
     /** The request. */
     private ServletRequest  request;
-    
+
     /** The response. */
     private ServletResponse response;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.FilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -35,7 +35,6 @@ public class SimpleFilterChain implements FilterChain {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.FilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -87,7 +87,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -109,7 +108,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getContentLength()
      */
     @Override
@@ -119,7 +117,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getHeader(java.lang.String)
      */
     @Override
@@ -129,7 +126,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getMethod()
      */
     @Override
@@ -139,7 +135,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getParameter(java.lang.String)
      */
     @Override
@@ -149,7 +144,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getQueryString()
      */
     @Override
@@ -159,7 +153,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemoteAddr()
      */
     @Override
@@ -169,7 +162,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemoteHost()
      */
     @Override
@@ -179,7 +171,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemotePort()
      */
     @Override
@@ -189,7 +180,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemoteUser()
      */
     @Override
@@ -199,7 +189,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRequestURI()
      */
     @Override
@@ -209,7 +198,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getSession()
      */
     @Override
@@ -219,7 +207,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getSession(boolean)
      */
     @Override
@@ -233,7 +220,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getUserPrincipal()
      */
     @Override
@@ -243,7 +229,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setContentLength(int)
      */
     @Override
@@ -253,7 +238,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setMethod(java.lang.String)
      */
     @Override
@@ -263,7 +247,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setQueryString(java.lang.String)
      */
     @Override
@@ -280,7 +263,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setRemoteAddr(java.lang.String)
      */
     @Override
@@ -290,7 +272,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setRemoteHost(java.lang.String)
      */
     @Override
@@ -310,7 +291,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setRequestURI(java.lang.String)
      */
     @Override
@@ -320,7 +300,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setUserPrincipal(java.security.Principal)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -50,16 +50,16 @@ public class SimpleHttpRequest extends Request {
 
     /** The request uri. */
     private String                    requestURI;
-    
+
     /** The query string. */
     private String                    queryString;
-    
+
     /** The remote user. */
     private String                    remoteUser;
-    
+
     /** The method. */
     private String                    method     = "GET";
-    
+
     /** The headers. */
     private final Map<String, String> headers    = new HashMap<>();
 
@@ -85,7 +85,9 @@ public class SimpleHttpRequest extends Request {
         this.remotePort = SimpleHttpRequest.nextRemotePort();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -96,14 +98,18 @@ public class SimpleHttpRequest extends Request {
     /**
      * Adds the parameter.
      *
-     * @param parameterName the parameter name
-     * @param parameterValue the parameter value
+     * @param parameterName
+     *            the parameter name
+     * @param parameterValue
+     *            the parameter value
      */
     public void addParameter(final String parameterName, final String parameterValue) {
         this.parameters.put(parameterName, parameterValue);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getContentLength()
      */
     @Override
@@ -111,7 +117,9 @@ public class SimpleHttpRequest extends Request {
         return this.content == null ? -1 : this.content.length;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getHeader(java.lang.String)
      */
     @Override
@@ -119,7 +127,9 @@ public class SimpleHttpRequest extends Request {
         return this.headers.get(headerName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getMethod()
      */
     @Override
@@ -127,7 +137,9 @@ public class SimpleHttpRequest extends Request {
         return this.method;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getParameter(java.lang.String)
      */
     @Override
@@ -135,7 +147,9 @@ public class SimpleHttpRequest extends Request {
         return this.parameters.get(parameterName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getQueryString()
      */
     @Override
@@ -143,7 +157,9 @@ public class SimpleHttpRequest extends Request {
         return this.queryString;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemoteAddr()
      */
     @Override
@@ -151,7 +167,9 @@ public class SimpleHttpRequest extends Request {
         return this.remoteAddr;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemoteHost()
      */
     @Override
@@ -159,7 +177,9 @@ public class SimpleHttpRequest extends Request {
         return this.remoteHost;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemotePort()
      */
     @Override
@@ -167,7 +187,9 @@ public class SimpleHttpRequest extends Request {
         return this.remotePort;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemoteUser()
      */
     @Override
@@ -175,7 +197,9 @@ public class SimpleHttpRequest extends Request {
         return this.remoteUser;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRequestURI()
      */
     @Override
@@ -183,7 +207,9 @@ public class SimpleHttpRequest extends Request {
         return this.requestURI;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getSession()
      */
     @Override
@@ -191,7 +217,9 @@ public class SimpleHttpRequest extends Request {
         return this.httpSession;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getSession(boolean)
      */
     @Override
@@ -203,7 +231,9 @@ public class SimpleHttpRequest extends Request {
         return this.httpSession;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getUserPrincipal()
      */
     @Override
@@ -211,7 +241,9 @@ public class SimpleHttpRequest extends Request {
         return this.principal;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setContentLength(int)
      */
     @Override
@@ -219,7 +251,9 @@ public class SimpleHttpRequest extends Request {
         this.content = new byte[length];
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setMethod(java.lang.String)
      */
     @Override
@@ -227,7 +261,9 @@ public class SimpleHttpRequest extends Request {
         this.method = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setQueryString(java.lang.String)
      */
     @Override
@@ -242,7 +278,9 @@ public class SimpleHttpRequest extends Request {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setRemoteAddr(java.lang.String)
      */
     @Override
@@ -250,7 +288,9 @@ public class SimpleHttpRequest extends Request {
         this.remoteAddr = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setRemoteHost(java.lang.String)
      */
     @Override
@@ -261,13 +301,16 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the remote user.
      *
-     * @param value the new remote user
+     * @param value
+     *            the new remote user
      */
     public void setRemoteUser(final String value) {
         this.remoteUser = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setRequestURI(java.lang.String)
      */
     @Override
@@ -275,7 +318,9 @@ public class SimpleHttpRequest extends Request {
         this.requestURI = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setUserPrincipal(java.security.Principal)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -42,7 +42,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -57,7 +56,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#flushBuffer()
      */
     @Override
@@ -72,7 +70,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getHeader(java.lang.String)
      */
     @Override
@@ -83,7 +80,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getHeaderNames()
      */
     @Override
@@ -93,7 +89,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getHeaderValues(java.lang.String)
      */
     @Override
@@ -104,7 +99,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getStatus()
      */
     @Override
@@ -123,7 +117,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#sendError(int)
      */
     @Override
@@ -133,7 +126,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#sendError(int, java.lang.String)
      */
     @Override
@@ -143,7 +135,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#setHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -160,7 +151,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#setStatus(int)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -36,11 +36,13 @@ public class SimpleHttpResponse extends Response {
 
     /** The status. */
     private int                             status  = 500;
-    
+
     /** The headers. */
     private final Map<String, List<String>> headers = new HashMap<>();
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -53,7 +55,9 @@ public class SimpleHttpResponse extends Response {
         this.headers.put(headerName, current);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#flushBuffer()
      */
     @Override
@@ -66,7 +70,9 @@ public class SimpleHttpResponse extends Response {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getHeader(java.lang.String)
      */
     @Override
@@ -75,7 +81,9 @@ public class SimpleHttpResponse extends Response {
         return headerValues == null ? null : Joiner.on(", ").join(headerValues);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getHeaderNames()
      */
     @Override
@@ -83,7 +91,9 @@ public class SimpleHttpResponse extends Response {
         return this.headers.keySet().toArray(new String[0]);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getHeaderValues(java.lang.String)
      */
     @Override
@@ -92,7 +102,9 @@ public class SimpleHttpResponse extends Response {
         return headerValues == null ? null : headerValues.toArray(new String[0]);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getStatus()
      */
     @Override
@@ -109,7 +121,9 @@ public class SimpleHttpResponse extends Response {
         return this.status == 401 ? "Unauthorized" : "Unknown";
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#sendError(int)
      */
     @Override
@@ -117,7 +131,9 @@ public class SimpleHttpResponse extends Response {
         this.status = rc;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#sendError(int, java.lang.String)
      */
     @Override
@@ -125,7 +141,9 @@ public class SimpleHttpResponse extends Response {
         this.status = rc;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#setHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -140,7 +158,9 @@ public class SimpleHttpResponse extends Response {
         this.headers.put(headerName, current);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#setStatus(int)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -29,7 +29,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getAttribute(java.lang.String)
      */
     @Override
@@ -39,7 +38,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getId()
      */
     @Override
@@ -49,7 +47,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#removeAttribute(java.lang.String)
      */
     @Override
@@ -59,7 +56,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#setAttribute(java.lang.String, java.lang.Object)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -27,7 +27,9 @@ public abstract class SimpleHttpSession implements HttpSession {
     /** The attributes. */
     private Map<String, Object> attributes;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getAttribute(java.lang.String)
      */
     @Override
@@ -35,7 +37,9 @@ public abstract class SimpleHttpSession implements HttpSession {
         return this.attributes.get(attributeName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getId()
      */
     @Override
@@ -43,7 +47,9 @@ public abstract class SimpleHttpSession implements HttpSession {
         return "WaffleId";
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#removeAttribute(java.lang.String)
      */
     @Override
@@ -51,7 +57,9 @@ public abstract class SimpleHttpSession implements HttpSession {
         this.attributes.remove(attributeName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#setAttribute(java.lang.String, java.lang.Object)
      */
     @Override
@@ -62,7 +70,8 @@ public abstract class SimpleHttpSession implements HttpSession {
     /**
      * Sets the attributes.
      *
-     * @param value the value
+     * @param value
+     *            the value
      */
     public void setAttributes(final Map<String, Object> value) {
         this.attributes = value;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -22,7 +22,9 @@ import org.apache.catalina.realm.RealmBase;
  */
 public abstract class SimpleRealm extends RealmBase {
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -24,7 +24,6 @@ public abstract class SimpleRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -33,7 +33,6 @@ public abstract class SimpleRequestDispatcher implements RequestDispatcher {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.RequestDispatcher#forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -31,7 +31,9 @@ public abstract class SimpleRequestDispatcher implements RequestDispatcher {
     /** The url. */
     private String url;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.RequestDispatcher#forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override
@@ -45,7 +47,8 @@ public abstract class SimpleRequestDispatcher implements RequestDispatcher {
     /**
      * Sets the url.
      *
-     * @param value the new url
+     * @param value
+     *            the new url
      */
     public void setUrl(final String value) {
         this.url = value;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleServletContext.java
@@ -28,7 +28,8 @@ public abstract class SimpleServletContext implements ServletContext {
     /**
      * Get Request Dispatcher used by Waffle.
      *
-     * @param url the url
+     * @param url
+     *            the url
      * @return the request dispatcher
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/format.xml
+++ b/Source/JNA/waffle-tomcat7/format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/Source/JNA/waffle-tomcat7/pom.xml
+++ b/Source/JNA/waffle-tomcat7/pom.xml
@@ -15,7 +15,6 @@
     <url>http://dblock.github.com/waffle/</url>
     <properties>
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <tomcat.version>7.0.63</tomcat.version>
     </properties>

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -36,10 +36,10 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
 
     /** The sid. */
     private final byte[]                      sid;
-    
+
     /** The sid string. */
     private final String                      sidString;
-    
+
     /** The groups. */
     private final Map<String, WindowsAccount> groups;
 
@@ -55,7 +55,8 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      */
     public GenericWindowsPrincipal(final IWindowsIdentity windowsIdentity, final PrincipalFormat principalFormat,
             final PrincipalFormat roleFormat) {
-        super(windowsIdentity.getFqn(), "", GenericWindowsPrincipal.getRoles(windowsIdentity, principalFormat, roleFormat));
+        super(windowsIdentity.getFqn(), "", GenericWindowsPrincipal.getRoles(windowsIdentity, principalFormat,
+                roleFormat));
         this.sid = windowsIdentity.getSid();
         this.sidString = windowsIdentity.getSidString();
         this.groups = GenericWindowsPrincipal.getGroups(windowsIdentity.getGroups());

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -53,7 +53,6 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#startInternal()
      */
     @Override
@@ -64,7 +63,6 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stopInternal()
      */
     @Override
@@ -75,7 +73,6 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
      * javax.servlet.http.HttpServletResponse, org.apache.catalina.deploy.LoginConfig)
      */

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -51,7 +51,9 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         this.log.debug("[waffle.apache.MixedAuthenticator] loaded");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#startInternal()
      */
     @Override
@@ -60,7 +62,9 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         super.startInternal();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stopInternal()
      */
     @Override
@@ -69,8 +73,11 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         this.log.info("[waffle.apache.MixedAuthenticator] stopped");
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request, javax.servlet.http.HttpServletResponse, org.apache.catalina.deploy.LoginConfig)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
+     * javax.servlet.http.HttpServletResponse, org.apache.catalina.deploy.LoginConfig)
      */
     @Override
     public boolean authenticate(final Request request, final HttpServletResponse response, final LoginConfig loginConfig) {

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -49,7 +49,9 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#startInternal()
      */
     @Override
@@ -58,7 +60,9 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         super.startInternal();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stopInternal()
      */
     @Override
@@ -67,8 +71,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.log.info("[waffle.apache.NegotiateAuthenticator] stopped");
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request, javax.servlet.http.HttpServletResponse, org.apache.catalina.deploy.LoginConfig)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
+     * javax.servlet.http.HttpServletResponse, org.apache.catalina.deploy.LoginConfig)
      */
     @Override
     public boolean authenticate(final Request request, final HttpServletResponse response, final LoginConfig loginConfig) {

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -51,7 +51,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#startInternal()
      */
     @Override
@@ -62,7 +61,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stopInternal()
      */
     @Override
@@ -73,7 +71,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
      * javax.servlet.http.HttpServletResponse, org.apache.catalina.deploy.LoginConfig)
      */

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -84,7 +84,6 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#getInfo()
      */
     @Override
@@ -214,7 +213,6 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#getAuthMethod()
      */
     @Override
@@ -224,7 +222,6 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#doLogin(org.apache.catalina.connector.Request,
      * java.lang.String, java.lang.String)
      */

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -44,19 +44,19 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /** The info. */
     protected String                 info;
-    
+
     /** The log. */
     protected Logger                 log;
-    
+
     /** The principal format. */
     protected PrincipalFormat        principalFormat     = PrincipalFormat.FQN;
-    
+
     /** The role format. */
     protected PrincipalFormat        roleFormat          = PrincipalFormat.FQN;
-    
+
     /** The allow guest login. */
     protected boolean                allowGuestLogin     = true;
-    
+
     /** The protocols. */
     protected Set<String>            protocols           = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
 
@@ -82,7 +82,9 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         this.auth = provider;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#getInfo()
      */
     @Override
@@ -210,7 +212,9 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#getAuthMethod()
      */
     @Override
@@ -218,8 +222,11 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.catalina.authenticator.AuthenticatorBase#doLogin(org.apache.catalina.connector.Request, java.lang.String, java.lang.String)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.catalina.authenticator.AuthenticatorBase#doLogin(org.apache.catalina.connector.Request,
+     * java.lang.String, java.lang.String)
      */
     @Override
     protected Principal doLogin(final Request request, final String username, final String password)

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WindowsRealm.java
@@ -29,7 +29,6 @@ public class WindowsRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override
@@ -39,7 +38,6 @@ public class WindowsRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getPassword(java.lang.String)
      */
     @Override
@@ -49,7 +47,6 @@ public class WindowsRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getPrincipal(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WindowsRealm.java
@@ -27,7 +27,9 @@ public class WindowsRealm extends RealmBase {
     /** The Constant NAME. */
     protected static final String NAME = "waffle.apache.WindowsRealm/1.0";
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override
@@ -35,7 +37,9 @@ public class WindowsRealm extends RealmBase {
         return WindowsRealm.NAME;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getPassword(java.lang.String)
      */
     @Override
@@ -43,7 +47,9 @@ public class WindowsRealm extends RealmBase {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getPrincipal(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -56,7 +56,8 @@ public class MixedAuthenticatorTests {
     /**
      * Sets the up.
      *
-     * @throws LifecycleException the lifecycle exception
+     * @throws LifecycleException
+     *             the lifecycle exception
      */
     @Before
     public void setUp() throws LifecycleException {
@@ -80,7 +81,8 @@ public class MixedAuthenticatorTests {
     /**
      * Tear down.
      *
-     * @throws LifecycleException the lifecycle exception
+     * @throws LifecycleException
+     *             the lifecycle exception
      */
     @After
     public void tearDown() throws LifecycleException {
@@ -251,7 +253,8 @@ public class MixedAuthenticatorTests {
     /**
      * Test programmatic security.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testProgrammaticSecurity() throws ServletException {

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -58,7 +58,8 @@ public class NegotiateAuthenticatorTests {
     /**
      * Sets the up.
      *
-     * @throws LifecycleException the lifecycle exception
+     * @throws LifecycleException
+     *             the lifecycle exception
      */
     @Before
     public void setUp() throws LifecycleException {
@@ -82,7 +83,8 @@ public class NegotiateAuthenticatorTests {
     /**
      * Tear down.
      *
-     * @throws LifecycleException the lifecycle exception
+     * @throws LifecycleException
+     *             the lifecycle exception
      */
     @After
     public void tearDown() throws LifecycleException {

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -55,7 +55,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_accept_both_protocols.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void should_accept_both_protocols() throws Exception {
@@ -69,7 +70,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_accept_ negotiate_protocol.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void should_accept_Negotiate_protocol() throws Exception {
@@ -82,7 +84,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_accept_ ntl m_protocol.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void should_accept_NTLM_protocol() throws Exception {
@@ -95,7 +98,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_refuse_other_protocol.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test(expected = RuntimeException.class)
     public void should_refuse_other_protocol() throws Exception {

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -37,7 +37,7 @@ public class WindowsAccountTests {
 
     /** The mock windows account. */
     private final MockWindowsAccount mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
-    
+
     /** The windows account. */
     private WindowsAccount           windowsAccount;
 
@@ -62,8 +62,10 @@ public class WindowsAccountTests {
     /**
      * Test is serializable.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ClassNotFoundException the class not found exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test
     public void testIsSerializable() throws IOException, ClassNotFoundException {

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -33,22 +33,22 @@ public abstract class SimpleContext implements Context {
 
     /** The path. */
     private String         path;
-    
+
     /** The name. */
     private String         name;
-    
+
     /** The realm. */
     private Realm          realm;
-    
+
     /** The parent. */
     private Container      parent;
-    
+
     /** The servlet context. */
     private ServletContext servletContext;
-    
+
     /** The pipeline. */
     private Pipeline       pipeline;
-    
+
     /** The authenticator. */
     private Authenticator  authenticator;
 
@@ -145,7 +145,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Authenticator Used By Waffle.
      *
-     * @param value the new authenticator
+     * @param value
+     *            the new authenticator
      */
     public void setAuthenticator(final Authenticator value) {
         this.authenticator = value;
@@ -154,7 +155,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Name Used By Waffle.
      *
-     * @param value the new name
+     * @param value
+     *            the new name
      */
     @Override
     public void setName(final String value) {
@@ -164,7 +166,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Parent Used By Waffle.
      *
-     * @param container the new parent
+     * @param container
+     *            the new parent
      */
     @Override
     public void setParent(final Container container) {
@@ -174,7 +177,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Path Used By Waffle.
      *
-     * @param value the new path
+     * @param value
+     *            the new path
      */
     @Override
     public void setPath(final String value) {
@@ -184,7 +188,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Pipeline Used By Waffle.
      *
-     * @param value the new pipeline
+     * @param value
+     *            the new pipeline
      */
     public void setPipeline(final Pipeline value) {
         this.pipeline = value;
@@ -193,7 +198,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Realm Used By Waffle.
      *
-     * @param value the new realm
+     * @param value
+     *            the new realm
      */
     @Override
     public void setRealm(final Realm value) {
@@ -203,7 +209,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Servlet Context Used By Waffle.
      *
-     * @param value the new servlet context
+     * @param value
+     *            the new servlet context
      */
     public void setServletContext(final ServletContext value) {
         this.servletContext = value;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleEngine.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleEngine.java
@@ -60,7 +60,8 @@ public abstract class SimpleEngine implements Engine {
     /**
      * Set Pipeline Used By Waffle.
      *
-     * @param value the new pipeline
+     * @param value
+     *            the new pipeline
      */
     public void setPipeline(final Pipeline value) {
         this.pipeline = value;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -29,11 +29,13 @@ public class SimpleFilterChain implements FilterChain {
 
     /** The request. */
     private ServletRequest  request;
-    
+
     /** The response. */
     private ServletResponse response;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.FilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -35,7 +35,6 @@ public class SimpleFilterChain implements FilterChain {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.FilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -50,22 +50,22 @@ public class SimpleHttpRequest extends Request {
 
     /** The request uri. */
     private String                    requestURI;
-    
+
     /** The query string. */
     private String                    queryString;
-    
+
     /** The remote user. */
     private String                    remoteUser;
-    
+
     /** The method. */
     private String                    method     = "GET";
-    
+
     /** The headers. */
     private final Map<String, String> headers    = new HashMap<>();
-    
+
     /** The parameters. */
     private final Map<String, String> parameters = new HashMap<>();
-    
+
     /** The content. */
     private byte[]                    content;
 
@@ -88,8 +88,10 @@ public class SimpleHttpRequest extends Request {
     /**
      * Adds the header.
      *
-     * @param headerName the header name
-     * @param headerValue the header value
+     * @param headerName
+     *            the header name
+     * @param headerValue
+     *            the header value
      */
     public void addHeader(final String headerName, final String headerValue) {
         this.headers.put(headerName, headerValue);
@@ -98,14 +100,18 @@ public class SimpleHttpRequest extends Request {
     /**
      * Adds the parameter.
      *
-     * @param parameterName the parameter name
-     * @param parameterValue the parameter value
+     * @param parameterName
+     *            the parameter name
+     * @param parameterValue
+     *            the parameter value
      */
     public void addParameter(final String parameterName, final String parameterValue) {
         this.parameters.put(parameterName, parameterValue);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getContentLength()
      */
     @Override
@@ -113,7 +119,9 @@ public class SimpleHttpRequest extends Request {
         return this.content == null ? -1 : this.content.length;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getHeader(java.lang.String)
      */
     @Override
@@ -121,7 +129,9 @@ public class SimpleHttpRequest extends Request {
         return this.headers.get(headerName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getMethod()
      */
     @Override
@@ -129,7 +139,9 @@ public class SimpleHttpRequest extends Request {
         return this.method;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getParameter(java.lang.String)
      */
     @Override
@@ -137,7 +149,9 @@ public class SimpleHttpRequest extends Request {
         return this.parameters.get(parameterName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getQueryString()
      */
     @Override
@@ -145,7 +159,9 @@ public class SimpleHttpRequest extends Request {
         return this.queryString;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemoteAddr()
      */
     @Override
@@ -153,7 +169,9 @@ public class SimpleHttpRequest extends Request {
         return this.remoteAddr;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemoteHost()
      */
     @Override
@@ -161,7 +179,9 @@ public class SimpleHttpRequest extends Request {
         return this.remoteHost;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemotePort()
      */
     @Override
@@ -169,7 +189,9 @@ public class SimpleHttpRequest extends Request {
         return this.remotePort;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemoteUser()
      */
     @Override
@@ -177,7 +199,9 @@ public class SimpleHttpRequest extends Request {
         return this.remoteUser;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRequestURI()
      */
     @Override
@@ -185,7 +209,9 @@ public class SimpleHttpRequest extends Request {
         return this.requestURI;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getSession()
      */
     @Override
@@ -193,7 +219,9 @@ public class SimpleHttpRequest extends Request {
         return this.httpSession;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getSession(boolean)
      */
     @Override
@@ -205,7 +233,9 @@ public class SimpleHttpRequest extends Request {
         return this.httpSession;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getUserPrincipal()
      */
     @Override
@@ -216,7 +246,8 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the content length.
      *
-     * @param length the new content length
+     * @param length
+     *            the new content length
      */
     public void setContentLength(final int length) {
         this.content = new byte[length];
@@ -225,7 +256,8 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the method.
      *
-     * @param value the new method
+     * @param value
+     *            the new method
      */
     public void setMethod(final String value) {
         this.method = value;
@@ -234,7 +266,8 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the query string.
      *
-     * @param queryValue the new query string
+     * @param queryValue
+     *            the new query string
      */
     public void setQueryString(final String queryValue) {
         this.queryString = queryValue;
@@ -247,7 +280,9 @@ public class SimpleHttpRequest extends Request {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setRemoteAddr(java.lang.String)
      */
     @Override
@@ -255,7 +290,9 @@ public class SimpleHttpRequest extends Request {
         this.remoteAddr = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setRemoteHost(java.lang.String)
      */
     @Override
@@ -266,7 +303,8 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the remote user.
      *
-     * @param value the new remote user
+     * @param value
+     *            the new remote user
      */
     public void setRemoteUser(final String value) {
         this.remoteUser = value;
@@ -275,13 +313,16 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the request uri.
      *
-     * @param value the new request uri
+     * @param value
+     *            the new request uri
      */
     public void setRequestURI(final String value) {
         this.requestURI = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setUserPrincipal(java.security.Principal)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -111,7 +111,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getContentLength()
      */
     @Override
@@ -121,7 +120,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getHeader(java.lang.String)
      */
     @Override
@@ -131,7 +129,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getMethod()
      */
     @Override
@@ -141,7 +138,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getParameter(java.lang.String)
      */
     @Override
@@ -151,7 +147,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getQueryString()
      */
     @Override
@@ -161,7 +156,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemoteAddr()
      */
     @Override
@@ -171,7 +165,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemoteHost()
      */
     @Override
@@ -181,7 +174,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemotePort()
      */
     @Override
@@ -191,7 +183,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemoteUser()
      */
     @Override
@@ -201,7 +192,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRequestURI()
      */
     @Override
@@ -211,7 +201,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getSession()
      */
     @Override
@@ -221,7 +210,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getSession(boolean)
      */
     @Override
@@ -235,7 +223,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getUserPrincipal()
      */
     @Override
@@ -282,7 +269,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setRemoteAddr(java.lang.String)
      */
     @Override
@@ -292,7 +278,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setRemoteHost(java.lang.String)
      */
     @Override
@@ -322,7 +307,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setUserPrincipal(java.security.Principal)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -37,11 +37,13 @@ public class SimpleHttpResponse extends Response {
 
     /** The status. */
     private int                             status  = 500;
-    
+
     /** The headers. */
     private final Map<String, List<String>> headers = new HashMap<>();
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -54,7 +56,9 @@ public class SimpleHttpResponse extends Response {
         this.headers.put(headerName, current);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#flushBuffer()
      */
     @Override
@@ -67,7 +71,9 @@ public class SimpleHttpResponse extends Response {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getHeader(java.lang.String)
      */
     @Override
@@ -76,7 +82,9 @@ public class SimpleHttpResponse extends Response {
         return headerValues == null ? null : Joiner.on(", ").join(headerValues);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getHeaderNames()
      */
     @Override
@@ -87,7 +95,8 @@ public class SimpleHttpResponse extends Response {
     /**
      * Gets the header values.
      *
-     * @param headerName the header name
+     * @param headerName
+     *            the header name
      * @return the header values
      */
     public String[] getHeaderValues(final String headerName) {
@@ -95,7 +104,9 @@ public class SimpleHttpResponse extends Response {
         return headerValues == null ? null : headerValues.toArray(new String[0]);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getStatus()
      */
     @Override
@@ -112,7 +123,9 @@ public class SimpleHttpResponse extends Response {
         return this.status == 401 ? "Unauthorized" : "Unknown";
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#sendError(int)
      */
     @Override
@@ -120,7 +133,9 @@ public class SimpleHttpResponse extends Response {
         this.status = rc;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#sendError(int, java.lang.String)
      */
     @Override
@@ -128,7 +143,9 @@ public class SimpleHttpResponse extends Response {
         this.status = rc;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#setHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -143,7 +160,9 @@ public class SimpleHttpResponse extends Response {
         this.headers.put(headerName, current);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#setStatus(int)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -43,7 +43,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -58,7 +57,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#flushBuffer()
      */
     @Override
@@ -73,7 +71,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getHeader(java.lang.String)
      */
     @Override
@@ -84,7 +81,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getHeaderNames()
      */
     @Override
@@ -106,7 +102,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getStatus()
      */
     @Override
@@ -125,7 +120,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#sendError(int)
      */
     @Override
@@ -135,7 +129,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#sendError(int, java.lang.String)
      */
     @Override
@@ -145,7 +138,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#setHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -162,7 +154,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#setStatus(int)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -29,7 +29,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getAttribute(java.lang.String)
      */
     @Override
@@ -39,7 +38,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getId()
      */
     @Override
@@ -49,7 +47,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#removeAttribute(java.lang.String)
      */
     @Override
@@ -59,7 +56,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#setAttribute(java.lang.String, java.lang.Object)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -27,7 +27,9 @@ public abstract class SimpleHttpSession implements HttpSession {
     /** The attributes. */
     private Map<String, Object> attributes;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getAttribute(java.lang.String)
      */
     @Override
@@ -35,7 +37,9 @@ public abstract class SimpleHttpSession implements HttpSession {
         return this.attributes.get(attributeName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getId()
      */
     @Override
@@ -43,7 +47,9 @@ public abstract class SimpleHttpSession implements HttpSession {
         return "WaffleId";
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#removeAttribute(java.lang.String)
      */
     @Override
@@ -51,7 +57,9 @@ public abstract class SimpleHttpSession implements HttpSession {
         this.attributes.remove(attributeName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#setAttribute(java.lang.String, java.lang.Object)
      */
     @Override
@@ -62,7 +70,8 @@ public abstract class SimpleHttpSession implements HttpSession {
     /**
      * Sets the attributes.
      *
-     * @param value the value
+     * @param value
+     *            the value
      */
     public void setAttributes(final Map<String, Object> value) {
         this.attributes = value;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimplePipeline.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimplePipeline.java
@@ -26,7 +26,9 @@ public abstract class SimplePipeline implements Pipeline {
     /** The valves. */
     private Valve[] valves;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.Pipeline#getValves()
      */
     @Override
@@ -37,7 +39,8 @@ public abstract class SimplePipeline implements Pipeline {
     /**
      * Sets the valves.
      *
-     * @param value the new valves
+     * @param value
+     *            the new valves
      */
     public void setValves(final Valve[] value) {
         this.valves = value;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimplePipeline.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimplePipeline.java
@@ -28,7 +28,6 @@ public abstract class SimplePipeline implements Pipeline {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.Pipeline#getValves()
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -22,7 +22,9 @@ import org.apache.catalina.realm.RealmBase;
  */
 public abstract class SimpleRealm extends RealmBase {
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -24,7 +24,6 @@ public abstract class SimpleRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -33,7 +33,6 @@ public abstract class SimpleRequestDispatcher implements RequestDispatcher {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.RequestDispatcher#forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -31,7 +31,9 @@ public abstract class SimpleRequestDispatcher implements RequestDispatcher {
     /** The url. */
     private String url;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.RequestDispatcher#forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override
@@ -45,7 +47,8 @@ public abstract class SimpleRequestDispatcher implements RequestDispatcher {
     /**
      * Sets the url.
      *
-     * @param value the new url
+     * @param value
+     *            the new url
      */
     public void setUrl(final String value) {
         this.url = value;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleServletContext.java
@@ -28,7 +28,8 @@ public abstract class SimpleServletContext implements ServletContext {
     /**
      * Get Request Dispatcher used by Waffle.
      *
-     * @param url the url
+     * @param url
+     *            the url
      * @return the request dispatcher
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/format.xml
+++ b/Source/JNA/waffle-tomcat8/format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/Source/JNA/waffle-tomcat8/pom.xml
+++ b/Source/JNA/waffle-tomcat8/pom.xml
@@ -18,7 +18,6 @@
         <maven.compiler.target>1.7</maven.compiler.target>
 
         <src.relative.loc>..</src.relative.loc>
-        <git.relative.loc>../../..</git.relative.loc>
 
         <tomcat.version>8.0.24</tomcat.version>
     </properties>

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -35,7 +35,7 @@ import waffle.windows.auth.WindowsAccount;
 public class GenericWindowsPrincipal extends GenericPrincipal {
 
     /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = 1L;
+    private static final long                 serialVersionUID = 1L;
 
     /** The sid. */
     private final byte[]                      sid;
@@ -58,7 +58,8 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      */
     public GenericWindowsPrincipal(final IWindowsIdentity windowsIdentity, final PrincipalFormat principalFormat,
             final PrincipalFormat roleFormat) {
-        super(windowsIdentity.getFqn(), "", GenericWindowsPrincipal.getRoles(windowsIdentity, principalFormat, roleFormat));
+        super(windowsIdentity.getFqn(), "", GenericWindowsPrincipal.getRoles(windowsIdentity, principalFormat,
+                roleFormat));
         this.sid = windowsIdentity.getSid();
         this.sidString = windowsIdentity.getSidString();
         this.groups = GenericWindowsPrincipal.getGroups(windowsIdentity.getGroups());

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -51,7 +51,9 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         this.log.debug("[waffle.apache.MixedAuthenticator] loaded");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#startInternal()
      */
     @Override
@@ -60,7 +62,9 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         super.startInternal();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stopInternal()
      */
     @Override
@@ -69,8 +73,11 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         this.log.info("[waffle.apache.MixedAuthenticator] stopped");
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request, javax.servlet.http.HttpServletResponse)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
+     * javax.servlet.http.HttpServletResponse)
      */
     @Override
     public boolean authenticate(final Request request, final HttpServletResponse response) {

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -53,7 +53,6 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#startInternal()
      */
     @Override
@@ -64,7 +63,6 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stopInternal()
      */
     @Override
@@ -75,7 +73,6 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
      * javax.servlet.http.HttpServletResponse)
      */

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -48,7 +48,9 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#startInternal()
      */
     @Override
@@ -57,7 +59,9 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         super.startInternal();
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stopInternal()
      */
     @Override
@@ -66,8 +70,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.log.info("[waffle.apache.NegotiateAuthenticator] stopped");
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request, javax.servlet.http.HttpServletResponse)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
+     * javax.servlet.http.HttpServletResponse)
      */
     @Override
     public boolean authenticate(final Request request, final HttpServletResponse response) {

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -50,7 +50,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#startInternal()
      */
     @Override
@@ -61,7 +60,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stopInternal()
      */
     @Override
@@ -72,7 +70,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#authenticate(org.apache.catalina.connector.Request,
      * javax.servlet.http.HttpServletResponse)
      */

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -213,7 +213,6 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#getAuthMethod()
      */
     @Override
@@ -223,7 +222,6 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#doLogin(org.apache.catalina.connector.Request,
      * java.lang.String, java.lang.String)
      */

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -44,19 +44,19 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /** The info. */
     protected String                 info;
-    
+
     /** The log. */
     protected Logger                 log;
-    
+
     /** The principal format. */
     protected PrincipalFormat        principalFormat     = PrincipalFormat.FQN;
-    
+
     /** The role format. */
     protected PrincipalFormat        roleFormat          = PrincipalFormat.FQN;
-    
+
     /** The allow guest login. */
     protected boolean                allowGuestLogin     = true;
-    
+
     /** The protocols. */
     protected Set<String>            protocols           = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
 
@@ -211,7 +211,9 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.authenticator.AuthenticatorBase#getAuthMethod()
      */
     @Override
@@ -219,8 +221,11 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.catalina.authenticator.AuthenticatorBase#doLogin(org.apache.catalina.connector.Request, java.lang.String, java.lang.String)
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.apache.catalina.authenticator.AuthenticatorBase#doLogin(org.apache.catalina.connector.Request,
+     * java.lang.String, java.lang.String)
      */
     @Override
     protected Principal doLogin(final Request request, final String username, final String password)

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WindowsRealm.java
@@ -29,7 +29,6 @@ public class WindowsRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override
@@ -39,7 +38,6 @@ public class WindowsRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getPassword(java.lang.String)
      */
     @Override
@@ -49,7 +47,6 @@ public class WindowsRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getPrincipal(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WindowsRealm.java
@@ -27,7 +27,9 @@ public class WindowsRealm extends RealmBase {
     /** The Constant NAME. */
     protected static final String NAME = "waffle.apache.WindowsRealm/1.0";
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override
@@ -35,7 +37,9 @@ public class WindowsRealm extends RealmBase {
         return WindowsRealm.NAME;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getPassword(java.lang.String)
      */
     @Override
@@ -43,7 +47,9 @@ public class WindowsRealm extends RealmBase {
         return null;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getPrincipal(java.lang.String)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -56,7 +56,8 @@ public class MixedAuthenticatorTests {
     /**
      * Sets the up.
      *
-     * @throws LifecycleException the lifecycle exception
+     * @throws LifecycleException
+     *             the lifecycle exception
      */
     @Before
     public void setUp() throws LifecycleException {
@@ -84,7 +85,8 @@ public class MixedAuthenticatorTests {
     /**
      * Tear down.
      *
-     * @throws LifecycleException the lifecycle exception
+     * @throws LifecycleException
+     *             the lifecycle exception
      */
     @After
     public void tearDown() throws LifecycleException {
@@ -250,7 +252,8 @@ public class MixedAuthenticatorTests {
     /**
      * Test programmatic security.
      *
-     * @throws ServletException the servlet exception
+     * @throws ServletException
+     *             the servlet exception
      */
     @Test
     public void testProgrammaticSecurity() throws ServletException {

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -58,7 +58,8 @@ public class NegotiateAuthenticatorTests {
     /**
      * Sets the up.
      *
-     * @throws LifecycleException the lifecycle exception
+     * @throws LifecycleException
+     *             the lifecycle exception
      */
     @Before
     public void setUp() throws LifecycleException {
@@ -82,7 +83,8 @@ public class NegotiateAuthenticatorTests {
     /**
      * Tear down.
      *
-     * @throws LifecycleException the lifecycle exception
+     * @throws LifecycleException
+     *             the lifecycle exception
      */
     @After
     public void tearDown() throws LifecycleException {

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -53,7 +53,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_accept_both_protocols.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void should_accept_both_protocols() throws Exception {
@@ -67,7 +68,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_accept_ negotiate_protocol.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void should_accept_Negotiate_protocol() throws Exception {
@@ -80,7 +82,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_accept_ ntl m_protocol.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test
     public void should_accept_NTLM_protocol() throws Exception {
@@ -93,7 +96,8 @@ public class WaffleAuthenticatorBaseTest {
     /**
      * Should_refuse_other_protocol.
      *
-     * @throws Exception the exception
+     * @throws Exception
+     *             the exception
      */
     @Test(expected = RuntimeException.class)
     public void should_refuse_other_protocol() throws Exception {

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -37,7 +37,7 @@ public class WindowsAccountTests {
 
     /** The mock windows account. */
     private final MockWindowsAccount mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
-    
+
     /** The windows account. */
     private WindowsAccount           windowsAccount;
 
@@ -62,8 +62,10 @@ public class WindowsAccountTests {
     /**
      * Test is serializable.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws ClassNotFoundException the class not found exception
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     * @throws ClassNotFoundException
+     *             the class not found exception
      */
     @Test
     public void testIsSerializable() throws IOException, ClassNotFoundException {

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -33,22 +33,22 @@ public abstract class SimpleContext implements Context {
 
     /** The path. */
     private String         path;
-    
+
     /** The name. */
     private String         name;
-    
+
     /** The realm. */
     private Realm          realm;
-    
+
     /** The parent. */
     private Container      parent;
-    
+
     /** The servlet context. */
     private ServletContext servletContext;
-    
+
     /** The pipeline. */
     private Pipeline       pipeline;
-    
+
     /** The authenticator. */
     private Authenticator  authenticator;
 
@@ -165,7 +165,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Authenticator Used By Waffle.
      *
-     * @param value the new authenticator
+     * @param value
+     *            the new authenticator
      */
     public void setAuthenticator(final Authenticator value) {
         this.authenticator = value;
@@ -174,7 +175,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Name Used By Waffle.
      *
-     * @param value the new name
+     * @param value
+     *            the new name
      */
     @Override
     public void setName(final String value) {
@@ -184,7 +186,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Parent Used By Waffle.
      *
-     * @param container the new parent
+     * @param container
+     *            the new parent
      */
     @Override
     public void setParent(final Container container) {
@@ -194,7 +197,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Path Used By Waffle.
      *
-     * @param value the new path
+     * @param value
+     *            the new path
      */
     @Override
     public void setPath(final String value) {
@@ -204,7 +208,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Pipeline Used By Waffle.
      *
-     * @param value the new pipeline
+     * @param value
+     *            the new pipeline
      */
     public void setPipeline(final Pipeline value) {
         this.pipeline = value;
@@ -213,7 +218,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Realm Used By Waffle.
      *
-     * @param value the new realm
+     * @param value
+     *            the new realm
      */
     @Override
     public void setRealm(final Realm value) {
@@ -223,7 +229,8 @@ public abstract class SimpleContext implements Context {
     /**
      * Set Servlet Context Used By Waffle.
      *
-     * @param value the new servlet context
+     * @param value
+     *            the new servlet context
      */
     public void setServletContext(final ServletContext value) {
         this.servletContext = value;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleEngine.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleEngine.java
@@ -50,7 +50,8 @@ public abstract class SimpleEngine implements Engine {
     /**
      * Set Pipeline Used By Waffle.
      *
-     * @param value the new pipeline
+     * @param value
+     *            the new pipeline
      */
     public void setPipeline(final Pipeline value) {
         this.pipeline = value;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -29,11 +29,13 @@ public class SimpleFilterChain implements FilterChain {
 
     /** The request. */
     private ServletRequest  request;
-    
+
     /** The response. */
     private ServletResponse response;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.FilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -35,7 +35,6 @@ public class SimpleFilterChain implements FilterChain {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.FilterChain#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -50,22 +50,22 @@ public class SimpleHttpRequest extends Request {
 
     /** The request uri. */
     private String                    requestURI;
-    
+
     /** The query string. */
     private String                    queryString;
-    
+
     /** The remote user. */
     private String                    remoteUser;
-    
+
     /** The method. */
     private String                    method     = "GET";
-    
+
     /** The headers. */
     private final Map<String, String> headers    = new HashMap<>();
-    
+
     /** The parameters. */
     private final Map<String, String> parameters = new HashMap<>();
-    
+
     /** The content. */
     private byte[]                    content;
 
@@ -88,8 +88,10 @@ public class SimpleHttpRequest extends Request {
     /**
      * Adds the header.
      *
-     * @param headerName the header name
-     * @param headerValue the header value
+     * @param headerName
+     *            the header name
+     * @param headerValue
+     *            the header value
      */
     public void addHeader(final String headerName, final String headerValue) {
         this.headers.put(headerName, headerValue);
@@ -98,14 +100,18 @@ public class SimpleHttpRequest extends Request {
     /**
      * Adds the parameter.
      *
-     * @param parameterName the parameter name
-     * @param parameterValue the parameter value
+     * @param parameterName
+     *            the parameter name
+     * @param parameterValue
+     *            the parameter value
      */
     public void addParameter(final String parameterName, final String parameterValue) {
         this.parameters.put(parameterName, parameterValue);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getContentLength()
      */
     @Override
@@ -113,7 +119,9 @@ public class SimpleHttpRequest extends Request {
         return this.content == null ? -1 : this.content.length;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getHeader(java.lang.String)
      */
     @Override
@@ -121,7 +129,9 @@ public class SimpleHttpRequest extends Request {
         return this.headers.get(headerName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getMethod()
      */
     @Override
@@ -129,7 +139,9 @@ public class SimpleHttpRequest extends Request {
         return this.method;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getParameter(java.lang.String)
      */
     @Override
@@ -137,7 +149,9 @@ public class SimpleHttpRequest extends Request {
         return this.parameters.get(parameterName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getQueryString()
      */
     @Override
@@ -145,7 +159,9 @@ public class SimpleHttpRequest extends Request {
         return this.queryString;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemoteAddr()
      */
     @Override
@@ -153,7 +169,9 @@ public class SimpleHttpRequest extends Request {
         return this.remoteAddr;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemoteHost()
      */
     @Override
@@ -161,7 +179,9 @@ public class SimpleHttpRequest extends Request {
         return this.remoteHost;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemotePort()
      */
     @Override
@@ -169,7 +189,9 @@ public class SimpleHttpRequest extends Request {
         return this.remotePort;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRemoteUser()
      */
     @Override
@@ -177,7 +199,9 @@ public class SimpleHttpRequest extends Request {
         return this.remoteUser;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getRequestURI()
      */
     @Override
@@ -185,7 +209,9 @@ public class SimpleHttpRequest extends Request {
         return this.requestURI;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getSession()
      */
     @Override
@@ -193,7 +219,9 @@ public class SimpleHttpRequest extends Request {
         return this.httpSession;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getSession(boolean)
      */
     @Override
@@ -205,7 +233,9 @@ public class SimpleHttpRequest extends Request {
         return this.httpSession;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#getUserPrincipal()
      */
     @Override
@@ -216,7 +246,8 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the content length.
      *
-     * @param length the new content length
+     * @param length
+     *            the new content length
      */
     public void setContentLength(final int length) {
         this.content = new byte[length];
@@ -225,7 +256,8 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the method.
      *
-     * @param value the new method
+     * @param value
+     *            the new method
      */
     public void setMethod(final String value) {
         this.method = value;
@@ -234,7 +266,8 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the query string.
      *
-     * @param queryValue the new query string
+     * @param queryValue
+     *            the new query string
      */
     public void setQueryString(final String queryValue) {
         this.queryString = queryValue;
@@ -247,7 +280,9 @@ public class SimpleHttpRequest extends Request {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setRemoteAddr(java.lang.String)
      */
     @Override
@@ -255,7 +290,9 @@ public class SimpleHttpRequest extends Request {
         this.remoteAddr = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setRemoteHost(java.lang.String)
      */
     @Override
@@ -266,7 +303,8 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the remote user.
      *
-     * @param value the new remote user
+     * @param value
+     *            the new remote user
      */
     public void setRemoteUser(final String value) {
         this.remoteUser = value;
@@ -275,13 +313,16 @@ public class SimpleHttpRequest extends Request {
     /**
      * Sets the request uri.
      *
-     * @param value the new request uri
+     * @param value
+     *            the new request uri
      */
     public void setRequestURI(final String value) {
         this.requestURI = value;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Request#setUserPrincipal(java.security.Principal)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -111,7 +111,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getContentLength()
      */
     @Override
@@ -121,7 +120,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getHeader(java.lang.String)
      */
     @Override
@@ -131,7 +129,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getMethod()
      */
     @Override
@@ -141,7 +138,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getParameter(java.lang.String)
      */
     @Override
@@ -151,7 +147,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getQueryString()
      */
     @Override
@@ -161,7 +156,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemoteAddr()
      */
     @Override
@@ -171,7 +165,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemoteHost()
      */
     @Override
@@ -181,7 +174,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemotePort()
      */
     @Override
@@ -191,7 +183,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRemoteUser()
      */
     @Override
@@ -201,7 +192,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getRequestURI()
      */
     @Override
@@ -211,7 +201,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getSession()
      */
     @Override
@@ -221,7 +210,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getSession(boolean)
      */
     @Override
@@ -235,7 +223,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#getUserPrincipal()
      */
     @Override
@@ -282,7 +269,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setRemoteAddr(java.lang.String)
      */
     @Override
@@ -292,7 +278,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setRemoteHost(java.lang.String)
      */
     @Override
@@ -322,7 +307,6 @@ public class SimpleHttpRequest extends Request {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Request#setUserPrincipal(java.security.Principal)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -37,11 +37,13 @@ public class SimpleHttpResponse extends Response {
 
     /** The status. */
     private int                             status  = 500;
-    
+
     /** The headers. */
     private final Map<String, List<String>> headers = new HashMap<>();
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -54,7 +56,9 @@ public class SimpleHttpResponse extends Response {
         this.headers.put(headerName, current);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#flushBuffer()
      */
     @Override
@@ -67,7 +71,9 @@ public class SimpleHttpResponse extends Response {
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getHeader(java.lang.String)
      */
     @Override
@@ -76,7 +82,9 @@ public class SimpleHttpResponse extends Response {
         return headerValues == null ? null : Joiner.on(", ").join(headerValues);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getHeaderNames()
      */
     @Override
@@ -87,7 +95,8 @@ public class SimpleHttpResponse extends Response {
     /**
      * Gets the header values.
      *
-     * @param headerName the header name
+     * @param headerName
+     *            the header name
      * @return the header values
      */
     public String[] getHeaderValues(final String headerName) {
@@ -95,7 +104,9 @@ public class SimpleHttpResponse extends Response {
         return headerValues == null ? null : headerValues.toArray(new String[0]);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#getStatus()
      */
     @Override
@@ -112,7 +123,9 @@ public class SimpleHttpResponse extends Response {
         return this.status == 401 ? "Unauthorized" : "Unknown";
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#sendError(int)
      */
     @Override
@@ -120,7 +133,9 @@ public class SimpleHttpResponse extends Response {
         this.status = rc;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#sendError(int, java.lang.String)
      */
     @Override
@@ -128,7 +143,9 @@ public class SimpleHttpResponse extends Response {
         this.status = rc;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#setHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -143,7 +160,9 @@ public class SimpleHttpResponse extends Response {
         this.headers.put(headerName, current);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.connector.Response#setStatus(int)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -43,7 +43,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#addHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -58,7 +57,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#flushBuffer()
      */
     @Override
@@ -73,7 +71,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getHeader(java.lang.String)
      */
     @Override
@@ -84,7 +81,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getHeaderNames()
      */
     @Override
@@ -106,7 +102,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#getStatus()
      */
     @Override
@@ -125,7 +120,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#sendError(int)
      */
     @Override
@@ -135,7 +129,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#sendError(int, java.lang.String)
      */
     @Override
@@ -145,7 +138,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#setHeader(java.lang.String, java.lang.String)
      */
     @Override
@@ -162,7 +154,6 @@ public class SimpleHttpResponse extends Response {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.connector.Response#setStatus(int)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -29,7 +29,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getAttribute(java.lang.String)
      */
     @Override
@@ -39,7 +38,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#getId()
      */
     @Override
@@ -49,7 +47,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#removeAttribute(java.lang.String)
      */
     @Override
@@ -59,7 +56,6 @@ public abstract class SimpleHttpSession implements HttpSession {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.http.HttpSession#setAttribute(java.lang.String, java.lang.Object)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -27,7 +27,9 @@ public abstract class SimpleHttpSession implements HttpSession {
     /** The attributes. */
     private Map<String, Object> attributes;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getAttribute(java.lang.String)
      */
     @Override
@@ -35,7 +37,9 @@ public abstract class SimpleHttpSession implements HttpSession {
         return this.attributes.get(attributeName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#getId()
      */
     @Override
@@ -43,7 +47,9 @@ public abstract class SimpleHttpSession implements HttpSession {
         return "WaffleId";
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#removeAttribute(java.lang.String)
      */
     @Override
@@ -51,7 +57,9 @@ public abstract class SimpleHttpSession implements HttpSession {
         this.attributes.remove(attributeName);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.http.HttpSession#setAttribute(java.lang.String, java.lang.Object)
      */
     @Override
@@ -62,7 +70,8 @@ public abstract class SimpleHttpSession implements HttpSession {
     /**
      * Sets the attributes.
      *
-     * @param value the value
+     * @param value
+     *            the value
      */
     public void setAttributes(final Map<String, Object> value) {
         this.attributes = value;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimplePipeline.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimplePipeline.java
@@ -26,7 +26,9 @@ public abstract class SimplePipeline implements Pipeline {
     /** The valves. */
     private Valve[] valves;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.Pipeline#getValves()
      */
     @Override
@@ -37,7 +39,8 @@ public abstract class SimplePipeline implements Pipeline {
     /**
      * Sets the valves.
      *
-     * @param value the new valves
+     * @param value
+     *            the new valves
      */
     public void setValves(final Valve[] value) {
         this.valves = value;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimplePipeline.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimplePipeline.java
@@ -28,7 +28,6 @@ public abstract class SimplePipeline implements Pipeline {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.Pipeline#getValves()
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -22,7 +22,9 @@ import org.apache.catalina.realm.RealmBase;
  */
 public abstract class SimpleRealm extends RealmBase {
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -24,7 +24,6 @@ public abstract class SimpleRealm extends RealmBase {
 
     /*
      * (non-Javadoc)
-     * 
      * @see org.apache.catalina.realm.RealmBase#getName()
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -33,7 +33,6 @@ public abstract class SimpleRequestDispatcher implements RequestDispatcher {
 
     /*
      * (non-Javadoc)
-     * 
      * @see javax.servlet.RequestDispatcher#forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -31,7 +31,9 @@ public abstract class SimpleRequestDispatcher implements RequestDispatcher {
     /** The url. */
     private String url;
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see javax.servlet.RequestDispatcher#forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)
      */
     @Override
@@ -45,7 +47,8 @@ public abstract class SimpleRequestDispatcher implements RequestDispatcher {
     /**
      * Sets the url.
      *
-     * @param value the new url
+     * @param value
+     *            the new url
      */
     public void setUrl(final String value) {
         this.url = value;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleServletContext.java
@@ -28,7 +28,8 @@ public abstract class SimpleServletContext implements ServletContext {
     /**
      * Get Request Dispatcher used by Waffle.
      *
-     * @param url the url
+     * @param url
+     *            the url
      * @return the request dispatcher
      */
     @Override


### PR DESCRIPTION
After some detective work based on working on the formatter plugin itself, it was discovered that for a long time this had not been working on waffle.  The issue had to due to making it a profile to match other usages but then using a property to determine the location.  It becamse obvious that maven does not handle that as expected so it was never picking up formatting.  After resolving the issue there was a good bit of formatting not being applied.  In addition on this, now using my own build-tools which has the formatting baked in.  It resulted in a small variation in formatting which was tracked on a separate commit line.  My copy was newer (not the latest mars version but close).  So now formatting will occur on builds as well compression which existed but was never setup before.