### PR TITLE
Fix handle leak in LSASS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#226](https://github.com/dblock/waffle/pull/226): Moving base to java 1.7
 * Introduction of diamond operator and try with resources
+* [#239](https://github.com/dblock/waffle/pull/239): Fix handle leak in LSASS.exe process.
 
 1.7.x Branch News (on 1.7.4)
 =================

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
@@ -109,7 +109,7 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
                     pfClientContextAttr, null);
 
             sc = new WindowsSecurityContextImpl();
-            sc.setCredentialsHandle(serverCredential.getHandle());
+            sc.setCredentialsHandle(serverCredential);
             sc.setSecurityPackage(securityPackage);
             sc.setSecurityContext(phNewServerContext);
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
@@ -115,7 +115,8 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
             ctx.setSecurityPackage(securityPackage);
             ctx.initialize(null, null, targetName);
 
-            // Starting from here ctx 'owns' the credentials handle
+            // Starting from here ctx 'owns' the credentials handle, so let's null out the
+            // variable. This will prevent the finally block below from disposing it right away.
             credentialsHandle = null;
 
             return ctx;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTests.java
@@ -126,7 +126,7 @@ public class NegotiateSecurityFilterTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             final SimpleHttpRequest request = new SimpleHttpRequest();
@@ -173,7 +173,7 @@ public class NegotiateSecurityFilterTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // filter chain

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
@@ -165,7 +165,7 @@ public class WindowsAuthProviderTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, targetName);
             // accept on the server
@@ -232,7 +232,7 @@ public class WindowsAuthProviderTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // accept on the server
@@ -277,7 +277,7 @@ public class WindowsAuthProviderTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, targetName);
             // accept on the server

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -102,7 +102,7 @@ public class MixedAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             final SimpleHttpRequest request = new SimpleHttpRequest();
@@ -166,7 +166,7 @@ public class MixedAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // negotiate

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -116,7 +116,7 @@ public class NegotiateAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             final SimpleHttpRequest request = new SimpleHttpRequest();
@@ -164,7 +164,7 @@ public class NegotiateAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // negotiate
@@ -227,7 +227,7 @@ public class NegotiateAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // negotiate

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -124,7 +124,7 @@ public class MixedAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             final SimpleHttpRequest request = new SimpleHttpRequest();
@@ -188,7 +188,7 @@ public class MixedAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // negotiate

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -135,7 +135,7 @@ public class NegotiateAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             final SimpleHttpRequest request = new SimpleHttpRequest();
@@ -183,7 +183,7 @@ public class NegotiateAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // negotiate
@@ -246,7 +246,7 @@ public class NegotiateAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // negotiate

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -128,7 +128,7 @@ public class MixedAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             final SimpleHttpRequest request = new SimpleHttpRequest();
@@ -190,7 +190,7 @@ public class MixedAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // negotiate

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -135,7 +135,7 @@ public class NegotiateAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             final SimpleHttpRequest request = new SimpleHttpRequest();
@@ -183,7 +183,7 @@ public class NegotiateAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // negotiate
@@ -246,7 +246,7 @@ public class NegotiateAuthenticatorTests {
             // initial client security context
             clientContext = new WindowsSecurityContextImpl();
             clientContext.setPrincipalName(WindowsAccountImpl.getCurrentUsername());
-            clientContext.setCredentialsHandle(clientCredentials.getHandle());
+            clientContext.setCredentialsHandle(clientCredentials);
             clientContext.setSecurityPackage(securityPackage);
             clientContext.initialize(null, null, WindowsAccountImpl.getCurrentUsername());
             // negotiate


### PR DESCRIPTION
I noticed that the handle count of the LSASS process would continuously go up on servers using Waffle. Stopping the Java process would result in the handle count to immediately drop back to a normal value.

After a bit of digging I found out that the `WindowsCredentialsHandleImpl` allocated in `acceptSecurityToken` was never disposed, causing the leak. To fix that, I've arranged for this object lifetime to be determined by the associated `WindowsSecurityContextImpl`, since everywhere I could find the server credentials always end up tightly bound to one of those --- that is unless someone is calling `WindowsAuthProviderImpl.getCurrent` directly, but in this case the caller is responsible of calling `dispose` on it.

With this modification the handle count of both the server process and LSASS remains stable.