### PR TITLE
Update WindowsSecurityContextImpl.java to handle SEC_E_BUFFER_TOO_SMALL

### DIFF
--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
@@ -147,6 +147,9 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
                 case WinError.SEC_E_INSUFFICIENT_MEMORY:
                     tokenSize += Sspi.MAX_TOKEN_SIZE;
                     break;
+                case WinError.SEC_E_BUFFER_TOO_SMALL:
+                    tokenSize += Sspi.MAX_TOKEN_SIZE;
+                    break;
                 case WinError.SEC_I_CONTINUE_NEEDED:
                     this.continueFlag = true;
                     break;
@@ -156,7 +159,7 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
                 default:
                     throw new Win32Exception(rc);
             }
-        } while (rc == WinError.SEC_E_INSUFFICIENT_MEMORY);
+        } while (rc == WinError.SEC_E_INSUFFICIENT_MEMORY || rc == WinError.SEC_E_BUFFER_TOO_SMALL);
     }
 
     /*


### PR DESCRIPTION
Although not documented as a valid return code on MSDN I am now at least the second Waffle user to see a WinError.SEC_E_BUFFER_TOO_SMALL return code in WindowsSecurityContextImpl.initialize. I can confirm that the following patch fixes the problem, but there is no way for a third party to test this because the reason why this seemingly invalid error code is returned and why only to some Windows users is still unknown. The changes themselves are trivial and practically risk-free.
A similar pull request has already been made last year and is still open: 
#128 opened on Aug 4, 2014 by kentcb 