### PR TITLE
#268 changes to authenticate when tomcat launched as service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Rework .net build to be mostly automatic using nuget
 * Change .net target to more modern .net 4.0 framework
 * [#296](https://github.com/dblock/waffle/pull/296): Added Tomcat 9 support.
+* [#268](https://github.com/dblock/waffle/pull/301): Cannot log in automatically on machine where Tomcat service is running
 
 1.8.0 (09/10/15)
 ================


### PR DESCRIPTION
This a PR for issue 'Cannot log in automatically on machine where Tomcat service is running #268'

After reading the comments on the issue, I understand that current code is calling AcquireCredentialsHandle every-time instead of just once and reusing the handle in subsequent calls.

