### PR TITLE
Don't allow SPNEGO NegTokenArg to start re-authentication.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.8.2 (?/??/16)
+================
+
+* [#338](https://github.com/dblock/waffle/pull/338): Don't allow SPNEGO NegTokenArg to start re-authentication process [@AriSuutariST](https://github.com/AriSuutariST). 
+
 1.8.1 (2/10/16)
 ================
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
@@ -132,16 +132,16 @@ public class AuthorizationHeader {
     /**
      * Checks if is SP nego message.
      *
-     * @return true, if is SP nego message
+     * @return true, if is SP nego message that contains NegTokenInit
      */
-    public boolean isSPNegoMessage() {
+    public boolean isSPNegTokenInitMessage() {
 
         if (this.isNull()) {
             return false;
         }
 
         final byte[] tokenBytes = this.getTokenBytes();
-        return SPNegoMessage.isSPNegoMessage(tokenBytes);
+        return SPNegoMessage.isNegTokenInit(tokenBytes);
     }
 
     /**
@@ -161,6 +161,6 @@ public class AuthorizationHeader {
             return false;
         }
 
-        return this.isNtlmType1Message() || this.isSPNegoMessage();
+        return this.isNtlmType1Message() || this.isSPNegTokenInitMessage();
     }
 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/SPNegoMessage.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/SPNegoMessage.java
@@ -27,25 +27,6 @@ public final class SPNegoMessage {
     // are two token types, NegTokenInit and NegTokenArg.
     // For details and specification, see
     // http://msdn.microsoft.com/en-us/library/ms995330.aspx
-    /**
-     * Checks if is SP nego message.
-     *
-     * @param message
-     *            the message
-     * @return true, if is SP nego message
-     */
-    public static boolean isSPNegoMessage(final byte[] message) {
-
-        // Message should always contains at least some kind of
-        // id byte and length. If it is too short, it
-        // cannot be a SPNEGO message.
-        if (message == null || message.length < 2) {
-            return false;
-        }
-
-        // Message is SPNEGO message if it is either NegTokenInit or NegTokenArg.
-        return SPNegoMessage.isNegTokenInit(message) || SPNegoMessage.isNegTokenArg(message);
-    }
 
     /**
      * Checks if is neg token init.
@@ -55,6 +36,14 @@ public final class SPNegoMessage {
      * @return true, if is neg token init
      */
     public static boolean isNegTokenInit(final byte[] message) {
+
+        // Message should always contains at least some kind of
+        // id byte and length. If it is too short, it
+        // cannot be a SPNEGO message.
+        if (message == null || message.length < 2) {
+            return false;
+        }
+
         // First byte should always be 0x60 (Application Constructed Object)
         if (message[0] != 0x60) {
             return false;
@@ -93,6 +82,14 @@ public final class SPNegoMessage {
      * @return true, if is neg token arg
      */
     public static boolean isNegTokenArg(final byte[] message) {
+
+        // Message should always contains at least some kind of
+        // id byte and length. If it is too short, it
+        // cannot be a SPNEGO message.
+        if (message == null || message.length < 2) {
+            return false;
+        }
+
         // Check if this is NegTokenArg packet, it's id is 0xa1
         if ((message[0] & 0xff) != 0xa1) {
             return false;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/SPNegoMessageTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/SPNegoMessageTests.java
@@ -43,19 +43,6 @@ public class SPNegoMessageTests {
     private static final byte[] badMessage           = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
     /**
-     * Test is sp nego message.
-     */
-    @Test
-    public void testIsSPNegoMessage() {
-        Assert.assertFalse(SPNegoMessage.isSPNegoMessage(null));
-        Assert.assertTrue(SPNegoMessage.isSPNegoMessage(SPNegoMessageTests.negTokenInitOk));
-        Assert.assertFalse(SPNegoMessage.isSPNegoMessage(SPNegoMessageTests.negTokenInitTooShort));
-        Assert.assertTrue(SPNegoMessage.isSPNegoMessage(SPNegoMessageTests.negTokenArgOk));
-        Assert.assertFalse(SPNegoMessage.isSPNegoMessage(SPNegoMessageTests.negTokenArgTooShort));
-        Assert.assertFalse(SPNegoMessage.isSPNegoMessage(SPNegoMessageTests.badMessage));
-    }
-
-    /**
      * Test is neg token init.
      */
     @Test

--- a/Source/JNA/waffle-tests/src/test/java/waffle/util/AuthorizationHeaderTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/util/AuthorizationHeaderTests.java
@@ -94,16 +94,16 @@ public class AuthorizationHeaderTests {
      * Test is sp nego message.
      */
     @Test
-    public void testIsSPNegoMessage() {
+    public void testIsSPNegTokenInitMessage() {
         final SimpleHttpRequest request = new SimpleHttpRequest();
         final AuthorizationHeader header = new AuthorizationHeader(request);
-        Assert.assertFalse(header.isSPNegoMessage());
+        Assert.assertFalse(header.isSPNegTokenInitMessage());
         request.addHeader("Authorization", "");
-        Assert.assertFalse(header.isSPNegoMessage());
+        Assert.assertFalse(header.isSPNegTokenInitMessage());
         request.addHeader(
                 "Authorization",
                 "Negotiate YHYGBisGAQUFAqBsMGqgMDAuBgorBgEEAYI3AgIKBgkqhkiC9xIBAgIGCSqGSIb3EgECAgYKKwYBBAGCNwICHqI2BDROVExNU1NQAAEAAACXsgjiAwADADEAAAAJAAkAKAAAAAYBsR0AAAAPR0xZQ0VSSU5FU0FE");
-        Assert.assertTrue(header.isSPNegoMessage());
+        Assert.assertTrue(header.isSPNegTokenInitMessage());
     }
 
     /**
@@ -141,6 +141,7 @@ public class AuthorizationHeaderTests {
 
         final BDDSoftAssertions softly = new BDDSoftAssertions();
         softly.thenThrownBy(new ThrowingCallable() {
+
             @Override
             public void call() throws Exception {
                 header.getTokenBytes();


### PR DESCRIPTION
Only NegTokenInit is similar to NTLM type 1 message, NegTokenArg occurs only when there is already an ongoing negotiation. Cleaned up method names a bit also to reflect this.

This should fix the first problem in issue #167.