### PR TITLE
[nunit] Set nuget version to use as 2.6.4

### DIFF
--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -1,4 +1,4 @@
 @echo off
 NuGet.exe install MSBuildTasks -OutputDirectory .\Tools\ -ExcludeVersion -NonInteractive
-NuGet.exe install NUnit.Runners -OutputDirectory .\Tools\ -ExcludeVersion -NonInteractive
+NuGet.exe install NUnit.Runners -OutputDirectory .\Tools\ -ExcludeVersion -NonInteractive -Version 2.6.4
 NuGet.exe install Wix.Toolset -OutputDirectory .\Tools\ -ExcludeVersion -NonInteractive


### PR DESCRIPTION
Fixes #348 

Quick fix solution is to leave us on version 2.6.4 of nunit until we can upgrade without affecting users currently trying to build application.