### PR TITLE
Update tomcat 9 and use standard java 8 instead of guava

### DIFF
--- a/Source/JNA/waffle-tomcat9/pom.xml
+++ b/Source/JNA/waffle-tomcat9/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <src.relative.loc>..</src.relative.loc>
 
-        <tomcat.version>9.0.0.M4</tomcat.version>
+        <tomcat.version>9.0.0.M8</tomcat.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -13,6 +13,7 @@ package waffle.apache;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Base64;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
@@ -24,8 +25,6 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.io.BaseEncoding;
 
 import waffle.util.AuthorizationHeader;
 import waffle.util.NtlmServletRequest;
@@ -162,7 +161,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             final byte[] continueTokenBytes = securityContext.getToken();
             if (continueTokenBytes != null && continueTokenBytes.length > 0) {
-                final String continueToken = BaseEncoding.base64().encode(continueTokenBytes);
+                final String continueToken = Base64.getEncoder().encodeToString(continueTokenBytes);
                 this.log.debug("continue token: {}", continueToken);
                 response.addHeader("WWW-Authenticate", securityPackage + " " + continueToken);
             }

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -13,6 +13,7 @@ package waffle.apache;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Base64;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -21,7 +22,6 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Win32Exception;
 
 import waffle.util.AuthorizationHeader;
@@ -120,7 +120,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
                 final byte[] continueTokenBytes = securityContext.getToken();
                 if (continueTokenBytes != null && continueTokenBytes.length > 0) {
-                    final String continueToken = BaseEncoding.base64().encode(continueTokenBytes);
+                    final String continueToken = Base64.getEncoder().encodeToString(continueTokenBytes);
                     this.log.debug("continue token: {}", continueToken);
                     response.addHeader("WWW-Authenticate", securityPackage + " " + continueToken);
                 }

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -11,6 +11,8 @@
  */
 package waffle.apache;
 
+import java.util.Base64;
+
 import javax.servlet.ServletException;
 
 import org.apache.catalina.Context;
@@ -22,7 +24,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Sspi;
 import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
 
@@ -130,7 +131,7 @@ public class MixedAuthenticatorTests {
             request.setQueryString("j_negotiate_check");
             request.setMethod("POST");
             request.setContentLength(0);
-            final String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
+            final String clientToken = Base64.getEncoder().encodeToString(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             final SimpleHttpResponse response = new SimpleHttpResponse();
             this.authenticator.authenticate(request, response);
@@ -190,7 +191,7 @@ public class MixedAuthenticatorTests {
             request.setQueryString("j_negotiate_check");
             String clientToken;
             while (true) {
-                clientToken = BaseEncoding.base64().encode(clientContext.getToken());
+                clientToken = Base64.getEncoder().encodeToString(clientContext.getToken());
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 final SimpleHttpResponse response = new SimpleHttpResponse();
@@ -207,7 +208,7 @@ public class MixedAuthenticatorTests {
                 Assert.assertEquals(401, response.getStatus());
                 final String continueToken = response.getHeader("WWW-Authenticate").substring(
                         securityPackage.length() + 1);
-                final byte[] continueTokenBytes = BaseEncoding.base64().decode(continueToken);
+                final byte[] continueTokenBytes = Base64.getDecoder().decode(continueToken);
                 Assertions.assertThat(continueTokenBytes.length).isGreaterThan(0);
                 final SecBufferDesc continueTokenBuffer = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, continueTokenBytes);
                 clientContext.initialize(clientContext.getHandle(), continueTokenBuffer,

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -11,6 +11,8 @@
  */
 package waffle.apache;
 
+import java.util.Base64;
+
 import org.apache.catalina.Context;
 import org.apache.catalina.Engine;
 import org.apache.catalina.LifecycleException;
@@ -22,7 +24,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Sspi;
 import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
 
@@ -138,7 +139,7 @@ public class NegotiateAuthenticatorTests {
             final SimpleHttpRequest request = new SimpleHttpRequest();
             request.setMethod("POST");
             request.setContentLength(0);
-            final String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
+            final String clientToken = Base64.getEncoder().encodeToString(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             final SimpleHttpResponse response = new SimpleHttpResponse();
             this.authenticator.authenticate(request, response);
@@ -187,7 +188,7 @@ public class NegotiateAuthenticatorTests {
             boolean authenticated = false;
             final SimpleHttpRequest request = new SimpleHttpRequest();
             while (true) {
-                final String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
+                final String clientToken = Base64.getEncoder().encodeToString(clientContext.getToken());
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 final SimpleHttpResponse response = new SimpleHttpResponse();
@@ -211,7 +212,7 @@ public class NegotiateAuthenticatorTests {
                 Assert.assertEquals(401, response.getStatus());
                 final String continueToken = response.getHeader("WWW-Authenticate").substring(
                         securityPackage.length() + 1);
-                final byte[] continueTokenBytes = BaseEncoding.base64().decode(continueToken);
+                final byte[] continueTokenBytes = Base64.getDecoder().decode(continueToken);
                 Assertions.assertThat(continueTokenBytes.length).isGreaterThan(0);
                 final SecBufferDesc continueTokenBuffer = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, continueTokenBytes);
                 clientContext.initialize(clientContext.getHandle(), continueTokenBuffer,
@@ -257,7 +258,7 @@ public class NegotiateAuthenticatorTests {
             SimpleHttpResponse response;
             SecBufferDesc continueTokenBuffer;
             while (true) {
-                clientToken = BaseEncoding.base64().encode(clientContext.getToken());
+                clientToken = Base64.getEncoder().encodeToString(clientContext.getToken());
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 response = new SimpleHttpResponse();
@@ -285,7 +286,7 @@ public class NegotiateAuthenticatorTests {
                 Assert.assertEquals(2, response.getHeaderNames().size());
                 Assert.assertEquals(401, response.getStatus());
                 continueToken = response.getHeader("WWW-Authenticate").substring(securityPackage.length() + 1);
-                continueTokenBytes = BaseEncoding.base64().decode(continueToken);
+                continueTokenBytes = Base64.getDecoder().decode(continueToken);
                 Assertions.assertThat(continueTokenBytes.length).isGreaterThan(0);
                 continueTokenBuffer = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, continueTokenBytes);
                 clientContext.initialize(clientContext.getHandle(), continueTokenBuffer,


### PR DESCRIPTION
As of now, tomcat 9 module no longer requires guava at all.