### PR TITLE
Update tomcat 8.5 and 9 with fixes for api changes Fixes #389

### DIFF
--- a/Source/JNA/waffle-tomcat85/pom.xml
+++ b/Source/JNA/waffle-tomcat85/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <tomcat.version>8.5.4</tomcat.version>
+        <tomcat.version>8.5.6</tomcat.version>
     </properties>
 
     <dependencies>

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -288,4 +288,14 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
             throw new RuntimeException(e);
         }
     }
+
+    /**
+     * XXX The 'doAuthenticate' is intended to replace 'authenticate' for needs like ours. In order to support old and
+     * new at this time, we will continue to have both for time being.
+     */
+    @Override
+    protected boolean doAuthenticate(Request request, HttpServletResponse response) throws IOException {
+        return this.authenticate(request, response);
+    }
+
 }

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -186,4 +186,14 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.sendUnauthorized(response);
         return false;
     }
+
+    /**
+     * XXX The 'doAuthenticate' is intended to replace 'authenticate' for needs like ours. In order to support old and
+     * new at this time, we will continue to have both for time being.
+     */
+    @Override
+    protected boolean doAuthenticate(Request request, HttpServletResponse response) throws IOException {
+        return this.authenticate(request, response);
+    }
+
 }

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -45,6 +45,11 @@ public class WaffleAuthenticatorBaseTest {
             public boolean authenticate(final Request request, final HttpServletResponse response) throws IOException {
                 return false;
             }
+
+            @Override
+            protected boolean doAuthenticate(Request request, HttpServletResponse response) throws IOException {
+                return false;
+            }
         };
     }
 

--- a/Source/JNA/waffle-tomcat9/pom.xml
+++ b/Source/JNA/waffle-tomcat9/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <tomcat.version>9.0.0.M9</tomcat.version>
+        <tomcat.version>9.0.0.M11</tomcat.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -287,4 +287,14 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
             throw new RuntimeException(e);
         }
     }
+
+    /**
+     * XXX The 'doAuthenticate' is intended to replace 'authenticate' for needs like ours. In order to support
+     * old and new at this time, we will continue to have both for time being.
+     */
+    @Override
+    protected boolean doAuthenticate(Request request, HttpServletResponse response) throws IOException {
+        return this.authenticate(request, response);
+    }
+
 }

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -186,4 +186,14 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.sendUnauthorized(response);
         return false;
     }
+
+    /**
+     * XXX The 'doAuthenticate' is intended to replace 'authenticate' for needs like ours. In order to support
+     * old and new at this time, we will continue to have both for time being.
+     */
+    @Override
+    protected boolean doAuthenticate(Request request, HttpServletResponse response) throws IOException {
+        return this.authenticate(request, response);
+    }
+
 }

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -45,6 +45,11 @@ public class WaffleAuthenticatorBaseTest {
             public boolean authenticate(final Request request, final HttpServletResponse response) throws IOException {
                 return false;
             }
+
+            @Override
+            protected boolean doAuthenticate(Request request, HttpServletResponse response) throws IOException {
+                return false;
+            }
         };
     }
 


### PR DESCRIPTION
Fixes #389 

The expectation of this fix is that compilation is performed against new code base but we still use the older method invocations and as such should support old and new without issues.